### PR TITLE
Measure Evaluation Grouping & other enhancements.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,10 @@ const App: React.FC = () => {
     setSelectedPatient(undefined);
     //set the selected measure:
     setSelectedMeasure(measureName);
+
+    setShowPopulations(false);
+
+    resetResults();
   };
 
   const [selectedPatient, setSelectedPatient] = useState<Patient | undefined>(undefined);
@@ -688,7 +692,7 @@ const App: React.FC = () => {
         selectedMeasure={selectedMeasure} selectedKnowledgeRepositoryServer={selectedKnowledgeRepo}
         selectedPatient={selectedPatient} />
 
-      <Results results={results} />
+      <Results results={results}/>
 
       <br />
       <ServerModal modalShow={serverModalShow} setModalShow={setServerModalShow} createServer={createServer} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,7 +300,7 @@ const App: React.FC = () => {
     }
 
     const evaluateMeasureFetch = new EvaluateMeasureFetch(selectedMeasureEvaluation,
-      selectedPatient, selectedMeasure, startDate, endDate, patientGroup, useSubject)
+       selectedMeasure, startDate, endDate, useSubject, selectedPatient, patientGroup)
 
     setResults('Calling ' + evaluateMeasureFetch.getUrl());
     // Set the loading state since this call can take a while to return
@@ -419,7 +419,7 @@ const App: React.FC = () => {
 
 
     const collectDataFetch = new CollectDataFetch(selectedDataRepo, selectedMeasure,
-      startDate, endDate, selectedPatient, patientGroup, useSubject)
+      startDate, endDate, useSubject, selectedPatient, patientGroup)
 
     let message = 'Calling ' + collectDataFetch.getUrl() + '...';
     setResults(message);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -638,7 +638,9 @@ const App: React.FC = () => {
         evaluateMeasure={evaluateMeasure} loading={loading} setModalShow={setServerModalShow}
         //Scoring now captured within evaluate measure card:
         populationScoring={populationScoring} showPopulations={showPopulations} measureScoringType={measureScoring}
-        selectedPatient={selectedPatient} patientGroup={selectedPatientGroup} />
+        selectedPatient={selectedPatient} patientGroup={selectedPatientGroup}
+        //used for href to subject
+        selectedDataRepo={selectedDataRepo} />
       <br />
       <ReceivingSystem showReceiving={showReceiving} setShowReceiving={setShowReceiving}
         servers={servers} setSelectedReceiving={setSelectedReceiving}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,8 +44,24 @@ const App: React.FC = () => {
   const [patientGroups, setPatientGroups] = useState<Map<string, PatientGroup> | undefined>(undefined);
 
   // Selected States
+
   const [selectedMeasure, setSelectedMeasure] = useState<string>('');
+  const setSelectedMeasureCaller = (measureName: SetStateAction<string>) => {
+    //reset our test comparator when new measure is selected:
+    setTestComparatorMap(new Map<Patient, MeasureComparisonManager>());
+    //reset our selectedPatient to ensure patient data lines up with measure
+    setSelectedPatient(undefined);
+    //set the selected measure:
+    setSelectedMeasure(measureName);
+  };
+
   const [selectedPatient, setSelectedPatient] = useState<Patient | undefined>(undefined);
+  const setSelectedPatientCaller = (patient: SetStateAction<Patient | undefined>) => {
+    //reset our test comparator when new patient is selected:
+    setTestComparatorMap(new Map<Patient, MeasureComparisonManager>());
+    setSelectedPatient(patient);
+  };
+
   const [selectedPatientGroup, setSelectedPatientGroup] = useState<PatientGroup | undefined>(undefined);
   const [selectedKnowledgeRepo, setSelectedKnowledgeRepo] = useState<Server>({
     id: '',
@@ -67,7 +83,7 @@ const App: React.FC = () => {
     clientSecret: '',
     scope: ''
   });
-  const [selectedMeasureEvaluationServer, setSelectedMeasureEvaluation] = useState<Server>({
+  const [selectedMeasureEvaluationServer, setSelectedMeasureEvaluationServer] = useState<Server>({
     id: '',
     baseUrl: '',
     authUrl: '',
@@ -122,24 +138,11 @@ const App: React.FC = () => {
   const [testComparatorMap, setTestComparatorMap] = useState<Map<Patient, MeasureComparisonManager>>(new Map());
 
 
-  const setSelectedMeasureCaller = (measureName: SetStateAction<string>) => {
-    //reset our test comparator:
-    setTestComparatorMap(new Map<Patient, MeasureComparisonManager>());
-
-    //reset our selectedPatient
-    setSelectedPatient(undefined);
-
-    //set the selected measure:
-    setSelectedMeasure(measureName);
-  };
-
   //tells us when app is busy loading and not to disrupt variable assignment
   const reportErrorToUser = ((source: string, err: any) => {
     const message = err.message;
     setResults(message);
   });
-
-
 
   useEffect(() => {
     HashParamUtils.buildHashParams();
@@ -200,7 +203,7 @@ const App: React.FC = () => {
     resetResults();
 
     setLoading(true);
-    if (!knowledgeRepo || !knowledgeRepo.hasOwnProperty('id')) {
+    if (!knowledgeRepo?.hasOwnProperty('id')) {
       setSelectedKnowledgeRepo(knowledgeRepo);
       setShowPopulations(false);
       HashParamUtils.clearCachedValues();
@@ -266,6 +269,8 @@ const App: React.FC = () => {
   // Function for calling the server to perform the measure evaluation
   const evaluateMeasure = async (useSubject: boolean) => {
     resetResults();
+    setTestComparatorMap(new Map<Patient, MeasureComparisonManager>());
+    
     clearPopulationCounts();
 
     // Make sure all required elements are set
@@ -625,7 +630,7 @@ const App: React.FC = () => {
       <br />
       <DataRepository showDataRepo={showDataRepo} setShowDataRepo={setShowDataRepo} servers={servers}
         selectedDataRepo={selectedDataRepo} patients={patients}
-        fetchPatients={fetchPatients} setSelectedPatient={setSelectedPatient}
+        fetchPatients={fetchPatients} setSelectedPatient={setSelectedPatientCaller}
         selectedPatient={selectedPatient}
         collectData={collectData} loading={loading} setModalShow={setServerModalShow}
         selectedMeasure={selectedMeasure}
@@ -633,7 +638,7 @@ const App: React.FC = () => {
         setSelectedPatientGroup={setSelectedPatientGroup} />
       <br />
       <MeasureEvaluation showMeasureEvaluation={showMeasureEvaluation} setShowMeasureEvaluation={setShowMeasureEvaluation}
-        servers={servers} setSelectedMeasureEvaluation={setSelectedMeasureEvaluation}
+        servers={servers} setSelectedMeasureEvaluation={setSelectedMeasureEvaluationServer}
         selectedMeasureEvaluation={selectedMeasureEvaluationServer} submitData={submitData}
         evaluateMeasure={evaluateMeasure} loading={loading} setModalShow={setServerModalShow}
         //Scoring now captured within evaluate measure card:
@@ -653,7 +658,8 @@ const App: React.FC = () => {
         items={testComparatorMap} compareTestResults={compareTestResults} loading={loading}
         startDate={startDate} endDate={endDate} selectedDataRepoServer={selectedDataRepo}  
         selectedPatientGroup={selectedPatientGroup} selectedMeasureEvaluationServer={selectedMeasureEvaluationServer}
-        selectedMeasure={selectedMeasure} selectedKnowledgeRepositoryServer={selectedKnowledgeRepo}/>
+        selectedMeasure={selectedMeasure} selectedKnowledgeRepositoryServer={selectedKnowledgeRepo}
+        selectedPatient={selectedPatient}/>
 
       <Results results={results} />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,7 @@ const App: React.FC = () => {
     clientSecret: '',
     scope: ''
   });
-  const [selectedMeasureEvaluation, setSelectedMeasureEvaluation] = useState<Server>({
+  const [selectedMeasureEvaluationServer, setSelectedMeasureEvaluation] = useState<Server>({
     id: '',
     baseUrl: '',
     authUrl: '',
@@ -269,7 +269,7 @@ const App: React.FC = () => {
     clearPopulationCounts();
 
     // Make sure all required elements are set
-    if (!selectedMeasureEvaluation || selectedMeasureEvaluation.baseUrl === '') {
+    if (!selectedMeasureEvaluationServer || selectedMeasureEvaluationServer.baseUrl === '') {
       setResults(Constants.error_measureEvaluationServer);
       return;
     }
@@ -299,7 +299,7 @@ const App: React.FC = () => {
       return;
     }
 
-    const evaluateMeasureFetch = new EvaluateMeasureFetch(selectedMeasureEvaluation,
+    const evaluateMeasureFetch = new EvaluateMeasureFetch(selectedMeasureEvaluationServer,
        selectedMeasure, startDate, endDate, useSubject, selectedPatient, patientGroup)
 
     setResults('Calling ' + evaluateMeasureFetch.getUrl());
@@ -444,7 +444,7 @@ const App: React.FC = () => {
     setShowPopulations(false);
 
     // Make sure all required elements are set
-    if (!selectedMeasureEvaluation) {
+    if (!selectedMeasureEvaluationServer) {
       setResults(Constants.error_measureEvaluationServer);
       return;
     }
@@ -457,7 +457,7 @@ const App: React.FC = () => {
     setLoading(true);
 
     try {
-      setResults(await new SubmitDataFetch(selectedMeasureEvaluation,
+      setResults(await new SubmitDataFetch(selectedMeasureEvaluationServer,
         selectedMeasure, collectedData).submitData(accessToken));
       setLoading(false);
     } catch (error: any) {
@@ -520,7 +520,7 @@ const App: React.FC = () => {
     // Make sure all required elements are set
     let missingData = '';
 
-    if (!selectedMeasureEvaluation || selectedMeasureEvaluation.baseUrl === '') {
+    if (!selectedMeasureEvaluationServer || selectedMeasureEvaluationServer.baseUrl === '') {
       missingData = Constants.error_measureEvaluationServer + '\n';
     }
 
@@ -582,7 +582,7 @@ const App: React.FC = () => {
         //patient belongs to this group, proceed:
         const mcMan = new MeasureComparisonManager(patientEntry,
           measureObj,
-          selectedMeasureEvaluation,
+          selectedMeasureEvaluationServer,
           startDate, endDate,
           accessToken);
 
@@ -634,7 +634,7 @@ const App: React.FC = () => {
       <br />
       <MeasureEvaluation showMeasureEvaluation={showMeasureEvaluation} setShowMeasureEvaluation={setShowMeasureEvaluation}
         servers={servers} setSelectedMeasureEvaluation={setSelectedMeasureEvaluation}
-        selectedMeasureEvaluation={selectedMeasureEvaluation} submitData={submitData}
+        selectedMeasureEvaluation={selectedMeasureEvaluationServer} submitData={submitData}
         evaluateMeasure={evaluateMeasure} loading={loading} setModalShow={setServerModalShow}
         //Scoring now captured within evaluate measure card:
         populationScoring={populationScoring} showPopulations={showPopulations} measureScoringType={measureScoring}
@@ -651,7 +651,9 @@ const App: React.FC = () => {
       <br />
       <TestingComparator showTestCompare={showTestCompare} setShowTestCompare={setShowTestCompare}
         items={testComparatorMap} compareTestResults={compareTestResults} loading={loading}
-        startDate={startDate} endDate={endDate} />
+        startDate={startDate} endDate={endDate} selectedDataRepoServer={selectedDataRepo}  
+        selectedPatientGroup={selectedPatientGroup} selectedMeasureEvaluationServer={selectedMeasureEvaluationServer}
+        selectedMeasure={selectedMeasure} selectedKnowledgeRepositoryServer={selectedKnowledgeRepo}/>
 
       <Results results={results} />
 

--- a/src/components/DataRepository.tsx
+++ b/src/components/DataRepository.tsx
@@ -26,21 +26,10 @@ interface props {
 }
 
 const DataRepository: React.FC<props> = ({
-  showDataRepo,
-  setShowDataRepo,
-  servers,
-  selectedDataRepo,
-  patients,
-  fetchPatients,
-  setSelectedPatient,
-  selectedPatient,
-  collectData,
-  loading,
-  setModalShow,
-  selectedMeasure,
-  groups,
-  setSelectedPatientGroup,
-}) => {
+  showDataRepo, setShowDataRepo, servers, selectedDataRepo, patients,
+  fetchPatients, setSelectedPatient, selectedPatient, collectData, loading,
+  setModalShow, selectedMeasure, groups, setSelectedPatientGroup }) => {
+    
   const [patientFilter, setPatientFilter] = useState<string>('');
   const [useGroupAsSubject, setUseGroupAsSubject] = useState<boolean>(true);
   const [filteredPatients, setFilteredPatients] = useState<Array<Patient | undefined>>([]);

--- a/src/components/DataRepository.tsx
+++ b/src/components/DataRepository.tsx
@@ -174,7 +174,7 @@ const DataRepository: React.FC<props> = ({
                   className='w-100 btn btn-primary btn-lg'
                   id='evaluate'
                   disabled={loading}
-                  onClick={(e) => collectData(useGroupAsSubject)}>
+                  onClick={(e) => collectData(useGroupAsSubject && buildSubjectText().length > 0)}>
                   Collect Data</Button>
               )}
             </div>

--- a/src/components/DataRepository.tsx
+++ b/src/components/DataRepository.tsx
@@ -199,7 +199,7 @@ const DataRepository: React.FC<props> = ({
                   onChange={useGroupAsSubjectHandler}
                   disabled={loading}>
                 </input>
-                {' subject=' + buildSubjectText()}
+                {' subject='}<a href={selectedDataRepo?.baseUrl + buildSubjectText()} target='_blank'>{buildSubjectText()}</a>
               </label>
             }
             {(!useGroupAsSubject || buildSubjectText().length === 0) && (

--- a/src/components/DataRepository.tsx
+++ b/src/components/DataRepository.tsx
@@ -199,7 +199,7 @@ const DataRepository: React.FC<props> = ({
                   onChange={useGroupAsSubjectHandler}
                   disabled={loading}>
                 </input>
-                {' subject='}<a href={selectedDataRepo?.baseUrl + buildSubjectText()} target='_blank'>{buildSubjectText()}</a>
+                {' subject='}<a href={selectedDataRepo?.baseUrl + buildSubjectText()} target='_blank' rel='noreferrer'>{buildSubjectText()}</a>
               </label>
             }
             {(!useGroupAsSubject || buildSubjectText().length === 0) && (

--- a/src/components/DataRepository.tsx
+++ b/src/components/DataRepository.tsx
@@ -134,7 +134,7 @@ const DataRepository: React.FC<props> = ({
           </div>
           <div className='row'>
             <div className='col-md-5 order-md-1'>
-              <select data-testid='data-repo-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedDataRepo?.baseUrl}
+              <select disabled={loading} data-testid='data-repo-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedDataRepo?.baseUrl}
                 onChange={(e) => fetchPatients(servers[e.target.selectedIndex - 1]!)}>
                 <option value=''>Select a Server...</option>
                 {servers.map((server, index) => (
@@ -146,11 +146,11 @@ const DataRepository: React.FC<props> = ({
               <OverlayTrigger placement={'top'} overlay={
                 <Tooltip>Add an Endpoint</Tooltip>
               }>
-                <Button variant='outline-primary' onClick={() => setModalShow(true)}>+</Button>
+                <Button disabled={loading} variant='outline-primary' onClick={() => setModalShow(true)}>+</Button>
               </OverlayTrigger>
             </div>
             <div className='col-md-6 order-md-2'>
-              <select data-testid='data-repo-patient-dropdown' className='custom-select d-block w-100' id='patient' value={selectedPatient?.id || ''}
+              <select disabled={loading} data-testid='data-repo-patient-dropdown' className='custom-select d-block w-100' id='patient' value={selectedPatient?.id || ''}
                 onChange={(e) => {
                   const selectedPatientId = e.target.value;
                   const selectedPatientObject = patients.find(

--- a/src/components/DataRepository.tsx
+++ b/src/components/DataRepository.tsx
@@ -29,7 +29,7 @@ const DataRepository: React.FC<props> = ({
   showDataRepo, setShowDataRepo, servers, selectedDataRepo, patients,
   fetchPatients, setSelectedPatient, selectedPatient, collectData, loading,
   setModalShow, selectedMeasure, groups, setSelectedPatientGroup }) => {
-    
+
   const [patientFilter, setPatientFilter] = useState<string>('');
   const [useGroupAsSubject, setUseGroupAsSubject] = useState<boolean>(true);
   const [filteredPatients, setFilteredPatients] = useState<Array<Patient | undefined>>([]);
@@ -48,6 +48,18 @@ const DataRepository: React.FC<props> = ({
       return '';
     }
   };
+
+  const buildSelectedSubjectText = (): string => {
+    if (selectedPatient?.id) {
+      return selectedPatient.display;
+    } else if (patientGroup?.id) {
+      return 'Group/' + patientGroup.id;
+    } else {
+      return '';
+    }
+  };
+
+  const selectedSubject = useGroupAsSubject && buildSelectedSubjectText().length > 0 ? buildSelectedSubjectText() + ' on ' + selectedDataRepo?.baseUrl : selectedDataRepo?.baseUrl ? 'ALL Patients on ' + selectedDataRepo?.baseUrl : 'None (no Data Repository selected)';
 
   useEffect(() => {
     // Update filtered patients and patient group based on selectedMeasure
@@ -77,7 +89,9 @@ const DataRepository: React.FC<props> = ({
 
     // Update the selected patient group outside the rendering phase
     setSelectedPatientGroup(updatedPatientGroup);
-  }, [patients, selectedMeasure, patientFilter, groups, setSelectedPatientGroup]);
+  },
+    //dependency array (when useEffect will trigger:)
+    [patients, selectedMeasure, patientFilter, groups, setSelectedPatientGroup]);
 
 
   return (
@@ -89,7 +103,7 @@ const DataRepository: React.FC<props> = ({
             <div className='col-md-8 order-md-2 text-muted' />
           ) : (
             <div className='col-md-8 order-md-2 text-muted'>
-              Selected Patient: {selectedPatient?.display}
+              Selected Subject: {selectedSubject}
             </div>
           )}
           <div className='col-md-1 order-md-3'>
@@ -120,7 +134,7 @@ const DataRepository: React.FC<props> = ({
           </div>
           <div className='row'>
             <div className='col-md-5 order-md-1'>
-              <select data-testid='data-repo-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedDataRepo!.baseUrl}
+              <select data-testid='data-repo-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedDataRepo?.baseUrl}
                 onChange={(e) => fetchPatients(servers[e.target.selectedIndex - 1]!)}>
                 <option value=''>Select a Server...</option>
                 {servers.map((server, index) => (
@@ -191,7 +205,7 @@ const DataRepository: React.FC<props> = ({
                 {' subject='}<a href={selectedDataRepo?.baseUrl + buildSubjectText()} target='_blank' rel='noreferrer'>{buildSubjectText()}</a>
               </label>
             }
-            {(!useGroupAsSubject || buildSubjectText().length === 0) && (
+            {((!useGroupAsSubject || buildSubjectText().length === 0) && selectedDataRepo?.baseUrl) && (
               <div>
                 {Constants.largeDataNOTE}
               </div>

--- a/src/components/DataRepository.tsx
+++ b/src/components/DataRepository.tsx
@@ -166,7 +166,7 @@ const DataRepository: React.FC<props> = ({
                   </option>
                 ))}
               </select>
-              <input type='text' className='form-control' placeholder='Filter patients...' value={patientFilter}
+              <input disabled={loading} type='text' className='form-control' placeholder='Filter patients...' value={patientFilter}
                 onChange={(e) => setPatientFilter(e.target.value)} />
             </div>
             <div className='col-md-5 order-md-2'>

--- a/src/components/KnowledgeRepository.tsx
+++ b/src/components/KnowledgeRepository.tsx
@@ -23,103 +23,103 @@ interface props {
 
 // KnowledgeRepository component displays the fields for selecting and using the Knowledge Repository
 const KnowledgeRepository: React.FC<props> = ({ showKnowledgeRepo, setShowKnowledgeRepo, servers,
-    fetchMeasures, selectedKnowledgeRepo, measures, setSelectedMeasure,
-    selectedMeasure, getDataRequirements, loading, setModalShow }) => {
-    
-    return (
-      <div className='card'>
-        <div className='card-header'>
-          <div className='row'>
-            <div className='col-md-3 order-md-1'>Knowledge Repository</div>
+  fetchMeasures, selectedKnowledgeRepo, measures, setSelectedMeasure,
+  selectedMeasure, getDataRequirements, loading, setModalShow }) => {
+
+  return (
+    <div className='card'>
+      <div className='card-header'>
+        <div className='row'>
+          <div className='col-md-3 order-md-1'>Knowledge Repository</div>
+          {showKnowledgeRepo ? (
+            <div className='col-md-8 order-md-2 text-muted' />
+          ) : (
+            <div data-testid='selected-measure-div' className='col-md-8 order-md-2 text-muted'>
+              Selected Measure: {selectedMeasure}
+            </div>
+          )}
+          <div className='col-md-1 order-md-3'>
             {showKnowledgeRepo ? (
-              <div className='col-md-8 order-md-2 text-muted'/>
+              <Button data-testid='knowledge-repo-hide-section-button' className='btn btn-primary btn-lg float-right' onClick={(e) => setShowKnowledgeRepo(false)}>
+                Hide
+              </Button>
             ) : (
-              <div data-testid='selected-measure-div' className='col-md-8 order-md-2 text-muted'>
-                Selected Measure: {selectedMeasure}
-              </div>
+              <Button data-testid='knowledge-repo-show-section-button' className='btn btn-primary btn-lg float-right' onClick={(e) => setShowKnowledgeRepo(true)}>
+                Show
+              </Button>
             )}
-            <div className='col-md-1 order-md-3'>
-              {showKnowledgeRepo ? (
-                <Button data-testid='knowledge-repo-hide-section-button' className='btn btn-primary btn-lg float-right' onClick={(e) => setShowKnowledgeRepo(false)}>
-                  Hide
+          </div>
+        </div>
+      </div>
+      {showKnowledgeRepo ? (
+        <div className='card-body'>
+          <div className='row'>
+            <div className='col-md-6 order-md-1'>
+              <label>Knowledge Repository Server</label>
+            </div>
+            <div className='col-md-3 order-md-2'>
+              <label>Measure</label>
+            </div>
+            <div className='col-md-3 order-md-3 text-right'>
+              <label style={{ fontSize: '0.8em' }}>Measure List Count: {measures.length}</label>
+            </div>
+          </div>
+          <div className='row'>
+            <div className='col-md-5 order-md-1'>
+              <select disabled={loading} data-testid='knowledge-repo-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedKnowledgeRepo?.baseUrl}
+                onChange={(e) => fetchMeasures(servers[e.target.selectedIndex - 1]!)}>
+                <option value={'Select a Server...'}>
+                  Select a Server...</option>
+                {servers.map((server: any, index: React.Key | null | undefined) => (
+                  <option key={index}>{server!.baseUrl}</option>
+                ))}
+              </select>
+            </div>
+            <div className='col-md-1 order-md-2'>
+              <OverlayTrigger placement={'top'} overlay={
+                <Tooltip>Add an Endpoint</Tooltip>
+              }>
+                <Button disabled={loading} data-testid='knowledge-repo-server-add-button' variant='outline-primary' onClick={() => setModalShow(true)}>+</Button>
+              </OverlayTrigger>
+            </div>
+            <div className='col-md-6 order-md-3'>
+              <select disabled={loading} data-testid='knowledge-repo-measure-dropdown' className='custom-select d-block w-100' id='measure' value={selectedMeasure}
+                onChange={(e) => setSelectedMeasure(e.target.value)}>
+                <option value=''>Select a Measure...</option>
+                {measures.map((measure, index) => (
+                  <option key={index}>{measure!.name}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className='row'>
+            <div className='col-md-5 order-md-2'>
+              <br />
+              {loading ? (
+                <Button data-testid='get-data-requirements-button-spinner' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}>
+                  <Spinner
+                    as='span'
+                    variant='light'
+                    size='sm'
+                    role='status'
+                    aria-hidden='true'
+                    animation='border' />
+                  Loading...
                 </Button>
               ) : (
-                <Button data-testid='knowledge-repo-show-section-button' className='btn btn-primary btn-lg float-right' onClick={(e) => setShowKnowledgeRepo(true)}>
-                  Show
+                <Button data-testid='get-data-requirements-button' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}
+                  onClick={(e) => getDataRequirements()}>
+                  Get Data Requirements
                 </Button>
               )}
             </div>
           </div>
         </div>
-          {showKnowledgeRepo ? (
-          <div className='card-body'>
-            <div className='row'>
-              <div className='col-md-6 order-md-1'>
-                <label>Knowledge Repository Server</label>
-              </div>
-              <div className='col-md-3 order-md-2'>
-                <label>Measure</label>
-              </div>
-              <div className='col-md-3 order-md-3 text-right'>
-                <label style={{ fontSize: '0.8em' }}>Measure List Count: {measures.length}</label>
-              </div>
-          </div>
-                <div className='row'>
-                    <div className='col-md-5 order-md-1'>
-                      <select data-testid='knowledge-repo-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedKnowledgeRepo?.baseUrl}
-                              onChange={(e) => fetchMeasures(servers[e.target.selectedIndex - 1]!)}>
-                          <option value={'Select a Server...'}>
-                          Select a Server...</option>
-                          {servers.map((server: any, index: React.Key | null | undefined) => (
-                              <option key={index}>{server!.baseUrl}</option>
-                          ))}
-                      </select>
-                    </div>
-                    <div className='col-md-1 order-md-2'>
-                        <OverlayTrigger placement={'top'} overlay={
-                            <Tooltip>Add an Endpoint</Tooltip>
-                            }>
-                          <Button data-testid='knowledge-repo-server-add-button' variant='outline-primary' onClick={() => setModalShow(true)}>+</Button>
-                        </OverlayTrigger>
-                    </div>
-                    <div className='col-md-6 order-md-3'>
-                      <select data-testid='knowledge-repo-measure-dropdown' className='custom-select d-block w-100' id='measure' value={selectedMeasure}
-                        onChange={(e) => setSelectedMeasure(e.target.value)}>
-                      <option value=''>Select a Measure...</option>
-                        {measures.map((measure, index) => (
-                          <option key={index}>{measure!.name}</option>
-                        ))}
-                      </select>
-                    </div>
-                </div>
-              <div className='row'>
-                <div className='col-md-5 order-md-2'>
-                  <br/>
-                  {loading ? (
-                    <Button data-testid='get-data-requirements-button-spinner' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}>
-                      <Spinner
-                        as='span'
-                        variant='light'
-                        size='sm'
-                        role='status'
-                        aria-hidden='true'
-                        animation='border'/>
-                        Loading...
-                    </Button>
-                  ):(
-                    <Button data-testid='get-data-requirements-button' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}
-                      onClick={(e) => getDataRequirements()}>
-                        Get Data Requirements
-                    </Button>
-                  )}
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div/>
-          )}
-      </div>
-    );
+      ) : (
+        <div />
+      )}
+    </div>
+  );
 };
 
 export default KnowledgeRepository;

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,7 +1,6 @@
-import React, {useState} from 'react';
-import {Button, Form, Modal} from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import {Server} from '../models/Server';
+import React from 'react';
+import { Button, Form, Modal } from 'react-bootstrap';
 
 // Props for LoginModal
 interface props {

--- a/src/components/MeasureEvaluation.tsx
+++ b/src/components/MeasureEvaluation.tsx
@@ -22,14 +22,16 @@ interface props {
   showPopulations: boolean;
   populationScoring: PopulationScoring[] | undefined;
   measureScoringType: string;
-  patientGroup?: PatientGroup | undefined;
-  selectedPatient?: Patient | undefined;
+  patientGroup?: PatientGroup;
+  selectedPatient?: Patient;
+  selectedDataRepo: Server | undefined;
 }
 
 // MeasureEvaluation component displays the fields for selecting and using the measure evaluation system
 const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeasureEvaluation, servers, setSelectedMeasureEvaluation,
   selectedMeasureEvaluation, submitData, evaluateMeasure, loading, setModalShow,
-  showPopulations, populationScoring, measureScoringType, selectedPatient, patientGroup }) => {
+  showPopulations, populationScoring, measureScoringType, selectedPatient, patientGroup,
+  selectedDataRepo }) => {
 
 
   const [useGroupAsSubject, setUseGroupAsSubject] = useState<boolean>(true);
@@ -142,7 +144,7 @@ const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeas
                 onChange={useGroupAsSubjectHandler}
                 disabled={loading}>
               </input>
-              {' subject=' + buildSubjectText()}
+              {' subject='}<a href={selectedDataRepo?.baseUrl + buildSubjectText()} target='_blank'>{buildSubjectText()}</a>
             </label>
             }
             {(!useGroupAsSubject || buildSubjectText().length === 0) && (

--- a/src/components/MeasureEvaluation.tsx
+++ b/src/components/MeasureEvaluation.tsx
@@ -130,7 +130,7 @@ const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeas
                 </Button>
               ) : (
                 <Button data-testid='mea-eva-evaluate-button' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}
-                  onClick={(e) => evaluateMeasure(useGroupAsSubject)}>
+                  onClick={(e) => evaluateMeasure(useGroupAsSubject && buildSubjectText().length > 0)}>
                   Evaluate Measure
                 </Button>
               )}

--- a/src/components/MeasureEvaluation.tsx
+++ b/src/components/MeasureEvaluation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {Button, OverlayTrigger, Spinner, Tooltip} from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import {Server} from '../models/Server';
@@ -13,7 +13,7 @@ interface props {
   setSelectedMeasureEvaluation: React.Dispatch<React.SetStateAction<Server>>;
   selectedMeasureEvaluation: Server | undefined;
   submitData: () => void;
-  evaluateMeasure: () => void;
+  evaluateMeasure: (b: boolean) => void;
   loading: boolean;
   setModalShow: React.Dispatch<React.SetStateAction<boolean>>;
 
@@ -26,6 +26,14 @@ interface props {
 const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeasureEvaluation, servers, setSelectedMeasureEvaluation, 
   selectedMeasureEvaluation, submitData, evaluateMeasure, loading, setModalShow,
   showPopulations, populationScoring, measureScoringType }) => {
+
+
+    const [bypassGroupCheck, setBypassGroupCheck] = useState<boolean>(false);
+
+    const bypassHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setBypassGroupCheck(event.target.checked);
+    };
+
     return (
       <div className='card'>
         <div className='card-header'>
@@ -67,6 +75,7 @@ const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeas
                       </OverlayTrigger>
                   </div>
               </div>
+
               <Populations populationScoring={populationScoring} showPopulations={showPopulations} measureScoringType={measureScoringType}/>
               <div className='row'>
                 <div className='col-md-5 order-md-2'>
@@ -103,10 +112,24 @@ const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeas
                         Loading...
                     </Button>
                   ):(
+                    <div>
                     <Button  data-testid='mea-eva-evaluate-button' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}
-                      onClick={(e) => evaluateMeasure()}>
+                      onClick={(e) => evaluateMeasure(bypassGroupCheck)}>
                         Evaluate Measure
                     </Button>
+                    <div>
+                      <label>
+                        <input
+                          type="checkbox"
+                          checked={bypassGroupCheck}
+                          onChange={bypassHandler}> 
+                          </input>
+                        {' Validate ALL Patient data on selected Data Repository server (If left unchecked, Group will be used as subject).'} 
+                        <br></br>
+                        {bypassGroupCheck && ' NOTE: Large amounts of Patient data may cause 504 timeout if complexity is too great.'}
+                      </label>
+                    </div>
+                    </div>
                   )}
                 </div>
               </div>

--- a/src/components/MeasureEvaluation.tsx
+++ b/src/components/MeasureEvaluation.tsx
@@ -76,7 +76,7 @@ const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeas
           </div>
           <div className='row'>
             <div className='col-md-5 order-md-1'>
-              <select data-testid='mea-eva-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedMeasureEvaluation!.baseUrl}
+              <select data-testid='mea-eva-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedMeasureEvaluation?.baseUrl}
                 onChange={(e) => setSelectedMeasureEvaluation(servers[e.target.selectedIndex - 1]!)}>
                 <option value=''>Select a Server...</option>
                 {servers.map((server, index) => (
@@ -147,7 +147,7 @@ const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeas
               {' subject='}<a href={selectedDataRepo?.baseUrl + buildSubjectText()} target='_blank' rel='noreferrer'>{buildSubjectText()}</a>
             </label>
             }
-            {(!useGroupAsSubject || buildSubjectText().length === 0) && (
+            {((!useGroupAsSubject || buildSubjectText().length === 0) && selectedMeasureEvaluation?.baseUrl) && (
               <div>
                 {Constants.largeDataNOTE}
               </div>

--- a/src/components/MeasureEvaluation.tsx
+++ b/src/components/MeasureEvaluation.tsx
@@ -76,7 +76,7 @@ const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeas
           </div>
           <div className='row'>
             <div className='col-md-5 order-md-1'>
-              <select data-testid='mea-eva-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedMeasureEvaluation?.baseUrl}
+              <select disabled={loading} data-testid='mea-eva-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedMeasureEvaluation?.baseUrl}
                 onChange={(e) => setSelectedMeasureEvaluation(servers[e.target.selectedIndex - 1]!)}>
                 <option value=''>Select a Server...</option>
                 {servers.map((server, index) => (
@@ -88,7 +88,7 @@ const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeas
               <OverlayTrigger placement={'top'} overlay={
                 <Tooltip>Add an Endpoint</Tooltip>
               }>
-                <Button variant='outline-primary' onClick={() => setModalShow(true)}>+</Button>
+                <Button disabled={loading} variant='outline-primary' onClick={() => setModalShow(true)}>+</Button>
               </OverlayTrigger>
             </div>
           </div>

--- a/src/components/MeasureEvaluation.tsx
+++ b/src/components/MeasureEvaluation.tsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
-import {Button, OverlayTrigger, Spinner, Tooltip} from 'react-bootstrap';
+import { Button, OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import {Server} from '../models/Server';
+import { Server } from '../models/Server';
 import Populations from './Populations';
 import { PopulationScoring } from '../models/PopulationScoring';
+import { Constants } from '../constants/Constants';
+import { PatientGroup } from '../models/PatientGroup';
+import { Patient } from '../models/Patient';
 
 // Props for MeasureEvaluation
 interface props {
@@ -16,129 +19,144 @@ interface props {
   evaluateMeasure: (b: boolean) => void;
   loading: boolean;
   setModalShow: React.Dispatch<React.SetStateAction<boolean>>;
-
   showPopulations: boolean;
   populationScoring: PopulationScoring[] | undefined;
   measureScoringType: string;
+  patientGroup?: PatientGroup | undefined;
+  selectedPatient?: Patient | undefined;
 }
 
 // MeasureEvaluation component displays the fields for selecting and using the measure evaluation system
-const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeasureEvaluation, servers, setSelectedMeasureEvaluation, 
+const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeasureEvaluation, servers, setSelectedMeasureEvaluation,
   selectedMeasureEvaluation, submitData, evaluateMeasure, loading, setModalShow,
-  showPopulations, populationScoring, measureScoringType }) => {
+  showPopulations, populationScoring, measureScoringType, selectedPatient, patientGroup }) => {
 
 
-    const [bypassGroupCheck, setBypassGroupCheck] = useState<boolean>(false);
+  const [useGroupAsSubject, setUseGroupAsSubject] = useState<boolean>(true);
 
-    const bypassHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setBypassGroupCheck(event.target.checked);
-    };
+  const useGroupAsSubjectHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setUseGroupAsSubject(event.target.checked);
+  };
 
-    return (
-      <div className='card'>
-        <div className='card-header'>
-          Measure Evaluation Service
-          {showMeasureEvaluation ? (
-            <Button data-testid='mea-eva-hide-section-button' className='btn btn-primary btn-lg float-right' 
+  const buildSubjectText = (): string => {
+    if (selectedPatient?.id) {
+      return 'Patient/' + selectedPatient.id;
+    } else if (patientGroup?.id) {
+      return 'Group/' + patientGroup.id;
+    } else {
+      return '';
+    }
+  };
+
+
+  return (
+    <div className='card'>
+      <div className='card-header'>
+        Measure Evaluation Service
+        {showMeasureEvaluation ? (
+          <Button data-testid='mea-eva-hide-section-button' className='btn btn-primary btn-lg float-right'
             onClick={(e) => setShowMeasureEvaluation(false)}>
-              Hide
-            </Button>
-          ) : (
-            <Button data-testid='mea-eva-show-section-button' className='btn btn-primary btn-lg float-right' 
+            Hide
+          </Button>
+        ) : (
+          <Button data-testid='mea-eva-show-section-button' className='btn btn-primary btn-lg float-right'
             onClick={(e) => setShowMeasureEvaluation(true)}>
-              Show
-            </Button>
-          )}
-        </div>
-          {showMeasureEvaluation ? (
-            <div className='card-body'>
-              <div className='row'>
-                <div className='col-md-6 order-md-1'>
-                  <label>Measure Evaluation Server</label>
-                </div>
-              </div>
-              <div className='row'>
-                <div className='col-md-5 order-md-1'>
-                  <select data-testid='mea-eva-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedMeasureEvaluation!.baseUrl}
-                    onChange={(e) => setSelectedMeasureEvaluation(servers[e.target.selectedIndex - 1]!)}>
-                    <option value=''>Select a Server...</option>
-                    {servers.map((server, index) => (
-                      <option key={index}>{server!.baseUrl}</option>
-                    ))}
-                  </select>
-                </div>
-                  <div className='col-md-1 order-md-2'>
-                      <OverlayTrigger placement={'top'} overlay={
-                          <Tooltip>Add an Endpoint</Tooltip>
-                      }>
-                          <Button variant='outline-primary' onClick={() => setModalShow(true)}>+</Button>
-                      </OverlayTrigger>
-                  </div>
-              </div>
-
-              <Populations populationScoring={populationScoring} showPopulations={showPopulations} measureScoringType={measureScoringType}/>
-              <div className='row'>
-                <div className='col-md-5 order-md-2'>
-                  <br/>
-                  {loading ? (
-                    <Button data-testid='mea-eva-submit-button-spinner' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}>
-                      <Spinner
-                        as='span'
-                        variant='light'
-                        size='sm'
-                        role='status'
-                        aria-hidden='true'
-                        animation='border'/>
-                        Loading...
-                    </Button>
-                  ):(
-                    <Button data-testid='mea-eva-submit-button' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}
-                      onClick={(e) => submitData()}>
-                        Submit Data
-                    </Button>
-                  )}
-                </div>
-                <div className='col-md-5 order-md-2'>
-                  <br/>
-                  {loading ? (
-                    <Button data-testid='mea-eva-evaluate-button-spinner' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}>
-                      <Spinner
-                        as='span'
-                        variant='light'
-                        size='sm'
-                        role='status'
-                        aria-hidden='true'
-                        animation='border'/>
-                        Loading...
-                    </Button>
-                  ):(
-                    <div>
-                    <Button  data-testid='mea-eva-evaluate-button' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}
-                      onClick={(e) => evaluateMeasure(bypassGroupCheck)}>
-                        Evaluate Measure
-                    </Button>
-                    <div>
-                      <label>
-                        <input
-                          type="checkbox"
-                          checked={bypassGroupCheck}
-                          onChange={bypassHandler}> 
-                          </input>
-                        {' Validate ALL Patient data on selected Data Repository server (If left unchecked, Group will be used as subject).'} 
-                        <br></br>
-                        {bypassGroupCheck && ' NOTE: Large amounts of Patient data may cause 504 timeout if complexity is too great.'}
-                      </label>
-                    </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div/>
-          )}
+            Show
+          </Button>
+        )}
       </div>
-    );
+      {showMeasureEvaluation ? (
+        <div className='card-body'>
+          <div className='row'>
+            <div className='col-md-6 order-md-1'>
+              <label>Measure Evaluation Server</label>
+            </div>
+          </div>
+          <div className='row'>
+            <div className='col-md-5 order-md-1'>
+              <select data-testid='mea-eva-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedMeasureEvaluation!.baseUrl}
+                onChange={(e) => setSelectedMeasureEvaluation(servers[e.target.selectedIndex - 1]!)}>
+                <option value=''>Select a Server...</option>
+                {servers.map((server, index) => (
+                  <option key={index}>{server!.baseUrl}</option>
+                ))}
+              </select>
+            </div>
+            <div className='col-md-1 order-md-2'>
+              <OverlayTrigger placement={'top'} overlay={
+                <Tooltip>Add an Endpoint</Tooltip>
+              }>
+                <Button variant='outline-primary' onClick={() => setModalShow(true)}>+</Button>
+              </OverlayTrigger>
+            </div>
+          </div>
+
+          <Populations populationScoring={populationScoring} showPopulations={showPopulations} measureScoringType={measureScoringType} />
+          <div className='row'>
+            <div className='col-md-5 order-md-2'>
+              <br />
+              {loading ? (
+                <Button data-testid='mea-eva-submit-button-spinner' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}>
+                  <Spinner
+                    as='span'
+                    variant='light'
+                    size='sm'
+                    role='status'
+                    aria-hidden='true'
+                    animation='border' />
+                  Loading...
+                </Button>
+              ) : (
+                <Button data-testid='mea-eva-submit-button' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}
+                  onClick={(e) => submitData()}>
+                  Submit Data
+                </Button>
+              )}
+            </div>
+            <div className='col-md-5 order-md-2'>
+              <br />
+              {loading ? (
+                <Button data-testid='mea-eva-evaluate-button-spinner' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}>
+                  <Spinner
+                    as='span'
+                    variant='light'
+                    size='sm'
+                    role='status'
+                    aria-hidden='true'
+                    animation='border' />
+                  Loading...
+                </Button>
+              ) : (
+                <Button data-testid='mea-eva-evaluate-button' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}
+                  onClick={(e) => evaluateMeasure(useGroupAsSubject)}>
+                  Evaluate Measure
+                </Button>
+              )}
+            </div>
+          </div>
+          <div className='row-md-1 ml-auto'>
+            {buildSubjectText().length > 0 && <label>
+              <input
+                type="checkbox"
+                checked={useGroupAsSubject}
+                onChange={useGroupAsSubjectHandler}
+                disabled={loading}>
+              </input>
+              {' subject=' + buildSubjectText()}
+            </label>
+            }
+            {(!useGroupAsSubject || buildSubjectText().length === 0) && (
+              <div>
+                {Constants.largeDataNOTE}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div />
+      )}
+    </div>
+  );
 };
 
 export default MeasureEvaluation;

--- a/src/components/MeasureEvaluation.tsx
+++ b/src/components/MeasureEvaluation.tsx
@@ -144,7 +144,7 @@ const MeasureEvaluation: React.FC<props> = ({ showMeasureEvaluation, setShowMeas
                 onChange={useGroupAsSubjectHandler}
                 disabled={loading}>
               </input>
-              {' subject='}<a href={selectedDataRepo?.baseUrl + buildSubjectText()} target='_blank'>{buildSubjectText()}</a>
+              {' subject='}<a href={selectedDataRepo?.baseUrl + buildSubjectText()} target='_blank' rel='noreferrer'>{buildSubjectText()}</a>
             </label>
             }
             {(!useGroupAsSubject || buildSubjectText().length === 0) && (

--- a/src/components/Populations.tsx
+++ b/src/components/Populations.tsx
@@ -11,10 +11,12 @@ interface props {
 // Populations component displays the population cards
 const Populations: React.FC<props> = ({ showPopulations, populationScoring, measureScoringType }) => {
 
-  const convertToID = (str: any | undefined):string => {
+  const convertToID = (str: any | undefined): string => {
     let strIn: string = '' + str;
     return (strIn.replace(' ', ''));
   }
+  const tableCount = populationScoring ? populationScoring.length : 0;
+  const widthPercentage = tableCount >= 3 ? '33%' : tableCount === 2 ? '49%' : '100%'; // Adjust based on count
 
   return (
     <div>
@@ -24,37 +26,40 @@ const Populations: React.FC<props> = ({ showPopulations, populationScoring, meas
             {'Measure Scoring Type: '}
             {measureScoringType && measureScoringType.length > 0 ? measureScoringType : 'N/A'}
           </h5>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '5px' }}>
 
-          {populationScoring && Array.from(populationScoring)
-            .map((scoring, index) => (
-              <div key={index + scoring.groupID}>
-                <table className="table mt-4" style={{ width: '100%', border: '2px solid lightgrey' }}>
-                  <thead style={{ width: '100%', background: '#F7F7F7' }}>
-                    <tr>
-                      <th>
-                        <h5 data-testid={'pops-group-id-' + convertToID(scoring.groupID)}>{'Group ID: ' + scoring.groupID}</h5>
-                      </th>
-                      <th>
-                        <h5 data-testid={'pops-group-score-type-' + convertToID(scoring?.groupScoring?.coding[0]?.code)}>
-                          {scoring.groupScoring &&
-                            'Scoring Type: ' + scoring.groupScoring.coding[0].code}
-                        </h5>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {scoring.groupPopulations?.map((pop, idx) => (
-                      <tr key={idx} className={`${pop.discrepancy ? 'fw-bold text-danger' : ''}`}>
-                        <td data-testid={'pops-group-code-' + convertToID(pop.code.coding[0].code)} className="text-start">{pop.code.coding[0].code}:</td>
-                        <td data-testid={'pops-group-count-' + convertToID(pop.count)}>{pop.count}</td>
+
+            {populationScoring && Array.from(populationScoring)
+              .map((scoring, index) => (
+                <div key={index + scoring.groupID} style={{ flexBasis: widthPercentage }}>
+                  <table className="table mt-4" style={{ width: '100%', border: '2px solid lightgrey' }}>
+                    <thead style={{ background: '#F7F7F7' }}>
+                      <tr>
+                        <th>
+                          <h6 data-testid={'pops-group-id-' + convertToID(scoring.groupID)}>{'Group ID: ' + scoring.groupID}</h6>
+                        </th>
+                        <th>
+                          <h5 data-testid={'pops-group-score-type-' + convertToID(scoring?.groupScoring?.coding[0]?.code)}>
+                            {scoring.groupScoring &&
+                              'Scoring Type: ' + scoring.groupScoring.coding[0].code}
+                          </h5>
+                        </th>
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody>
+                      {scoring.groupPopulations?.map((pop, idx) => (
+                        <tr key={idx} className={`${pop.discrepancy ? 'fw-bold text-danger' : ''}`}>
+                          <td style={{ width: '95%', paddingLeft: '10px' }} data-testid={'pops-group-code-' + convertToID(pop.code.coding[0].code)} className="text-start">{pop.code.coding[0].code}:</td>
+                          <td style={{ width: '5%' }} data-testid={'pops-group-count-' + convertToID(pop.count)}>{pop.count}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
 
-              </div>
-            ))
-          }
+                </div>
+              ))
+            }
+          </div>
         </div>
       ) : (
         <div />

--- a/src/components/ReceivingSystem.tsx
+++ b/src/components/ReceivingSystem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {Button, OverlayTrigger, Spinner, Tooltip} from 'react-bootstrap';
+import { Button, OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import {Server} from '../models/Server';
+import { Server } from '../models/Server';
 
 // Props for ReceivingSystem
 interface props {
@@ -17,76 +17,76 @@ interface props {
 
 // ReceivingSystem component displays the fields for selecting and using the receiving system
 const ReceivingSystem: React.FC<props> = ({ showReceiving, setShowReceiving, servers, setSelectedReceiving,
-    selectedReceiving, postMeasureReport, loading, setModalShow }) => {
-    return (
-      <div className='card'>
-        <div className='card-header'>
-          Receiving System
-          {showReceiving ? (
-            <Button data-testid='rec-sys-hide-section-button' className='btn btn-primary btn-lg float-right' 
+  selectedReceiving, postMeasureReport, loading, setModalShow }) => {
+  return (
+    <div className='card'>
+      <div className='card-header'>
+        Receiving System
+        {showReceiving ? (
+          <Button data-testid='rec-sys-hide-section-button' className='btn btn-primary btn-lg float-right'
             onClick={(e) => setShowReceiving(false)}>
-              Hide
-            </Button>
-          ) : (
-            <Button data-testid='rec-sys-show-section-button' className='btn btn-primary btn-lg float-right' 
+            Hide
+          </Button>
+        ) : (
+          <Button data-testid='rec-sys-show-section-button' className='btn btn-primary btn-lg float-right'
             onClick={(e) => setShowReceiving(true)}>
-              Show
-            </Button>
-          )}
-        </div>
-          {showReceiving ? (
-            <div className='card-body'>
-              <div className='row'>
-                <div className='col-md-6 order-md-1'>
-                  <label>Receiving System Server</label>
-                </div>
-              </div>
-              <div className='row'>
-                <div className='col-md-5 order-md-1'>
-                  <select data-testid='rec-sys-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedReceiving!.baseUrl}
-                    onChange={(e) => setSelectedReceiving(servers[e.target.selectedIndex - 1]!)}>
-                    <option value=''>Select a Server...</option>
-                    {servers.map((server, index) => (
-                      <option key={index}>{server!.baseUrl}</option>
-                    ))}
-                  </select>
-                </div>
-                  <div className='col-md-1 order-md-2'>
-                      <OverlayTrigger placement={'top'} overlay={
-                          <Tooltip>Add an Endpoint</Tooltip>
-                      }>
-                          <Button variant='outline-primary' onClick={() => setModalShow(true)}>+</Button>
-                      </OverlayTrigger>
-                  </div>
-              </div>
-              <div className='row'>
-                <div className='col-md-5 order-md-2'>
-                  <br/>
-                  {loading ? (
-                    <Button data-testid='rec-sys-submit-button-spinner' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}>
-                      <Spinner
-                        as='span'
-                        variant='light'
-                        size='sm'
-                        role='status'
-                        aria-hidden='true'
-                        animation='border'/>
-                        Loading...
-                    </Button>
-                  ):(
-                    <Button data-testid='rec-sys-submit-button' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}
-                      onClick={(e) => postMeasureReport()}>
-                        Post Measure Report
-                    </Button>
-                  )}
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div/>
-          )}
+            Show
+          </Button>
+        )}
       </div>
-    );
+      {showReceiving ? (
+        <div className='card-body'>
+          <div className='row'>
+            <div className='col-md-6 order-md-1'>
+              <label>Receiving System Server</label>
+            </div>
+          </div>
+          <div className='row'>
+            <div className='col-md-5 order-md-1'>
+              <select disabled={loading} data-testid='rec-sys-server-dropdown' className='custom-select d-block w-100' id='server' value={selectedReceiving!.baseUrl}
+                onChange={(e) => setSelectedReceiving(servers[e.target.selectedIndex - 1]!)}>
+                <option value=''>Select a Server...</option>
+                {servers.map((server, index) => (
+                  <option key={index}>{server!.baseUrl}</option>
+                ))}
+              </select>
+            </div>
+            <div className='col-md-1 order-md-2'>
+              <OverlayTrigger placement={'top'} overlay={
+                <Tooltip>Add an Endpoint</Tooltip>
+              }>
+                <Button disabled={loading} variant='outline-primary' onClick={() => setModalShow(true)}>+</Button>
+              </OverlayTrigger>
+            </div>
+          </div>
+          <div className='row'>
+            <div className='col-md-5 order-md-2'>
+              <br />
+              {loading ? (
+                <Button data-testid='rec-sys-submit-button-spinner' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}>
+                  <Spinner
+                    as='span'
+                    variant='light'
+                    size='sm'
+                    role='status'
+                    aria-hidden='true'
+                    animation='border' />
+                  Loading...
+                </Button>
+              ) : (
+                <Button data-testid='rec-sys-submit-button' className='w-100 btn btn-primary btn-lg' id='getData' disabled={loading}
+                  onClick={(e) => postMeasureReport()}>
+                  Post Measure Report
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div />
+      )}
+    </div>
+  );
 };
 
 export default ReceivingSystem;

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -9,17 +9,11 @@ interface props {
 // Results component displays the status messages
 const Results: React.FC<props> = ({ results }) => {
   return (
-    results.length > 0 ?
-      (<div className='row mt-4' >
-        <div className='col-md-12 order-md-1'>
-          <Form.Control data-testid='results-text' as='textarea' name='results' rows={20} value={results} readOnly />
-        </div>
-      </div >)
-
-      :
-
-      (<div></div>)
-
+    <div className='row mt-4' >
+      <div className='col-md-12 order-md-1'>
+        <Form.Control data-testid='results-text' as='textarea' name='results' rows={20} value={results} readOnly />
+      </div>
+    </div >
   );
 };
 

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -9,11 +9,16 @@ interface props {
 // Results component displays the status messages
 const Results: React.FC<props> = ({ results }) => {
   return (
-      <div className='row mt-4'>
+    results.length > 0 ?
+      (<div className='row mt-4' >
         <div className='col-md-12 order-md-1'>
           <Form.Control data-testid='results-text' as='textarea' name='results' rows={20} value={results} readOnly />
         </div>
-      </div>
+      </div >)
+
+      :
+
+      (<div></div>)
 
   );
 };

--- a/src/components/TestingComparator.tsx
+++ b/src/components/TestingComparator.tsx
@@ -130,7 +130,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
             {items.size > 0 ? (
 
               <div>
-                <Table size='sm' >
+                <Table size='sm' style={{ marginBottom: '0px' }}>
                   <thead className="text-center">
                     <tr>
                       <th colSpan={3} style={{ width: '100%', border: 'none', padding: '0px' }}>
@@ -140,75 +140,84 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                   </thead>
                   <tbody>
                     <tr>
-                      <td style={{ border: 'none', verticalAlign: 'top', borderRight: '1px solid lightgrey' }}>
-                        <tr>
-                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
-                            Patients Evaluated:
-                          </td>
-                          <td data-testid={'test-comp-pat-eval-count'} style={{ minWidth: '10px', width: '100%', border: 'none' }}>{items.size}</td>
-                        </tr>
-                        <tr>
-                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
-                            Discrepancies Found:
-                          </td>
-                          <td data-testid={'test-comp-disc-found-count'} style={{ minWidth: '10px', width: '100%', border: 'none' }}>{trueCount}</td>
-                        </tr>
-                        <tr>
-                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
-                            Matching Data Found:
-                          </td>
-                          <td data-testid={'test-comp-match-count'} style={{ minWidth: '10px', width: '100%', border: 'none' }}>{falseCount}</td>
-                        </tr>
+                      <td style={{ borderRight: '1px solid lightgrey', borderBottom: 'none' }}>
+                        <Table size='sm' borderless>
+                          <tbody>
+                            <tr>
+                              <td className="text-start" style={{ minWidth: '215px' }}>
+                                Patients Evaluated:
+                              </td>
+                              <td data-testid={'test-comp-pat-eval-count'} style={{ minWidth: '10px', width: '100%' }}>{items.size}</td>
+                            </tr>
+                            <tr>
+                              <td className="text-start" style={{ minWidth: '215px' }}>
+                                Discrepancies Found:
+                              </td>
+                              <td data-testid={'test-comp-disc-found-count'} style={{ minWidth: '10px', width: '100%' }}>{trueCount}</td>
+                            </tr>
+                            <tr>
+                              <td className="text-start" style={{ minWidth: '215px' }}>
+                                Matching Data Found:
+                              </td>
+                              <td data-testid={'test-comp-match-count'} style={{ minWidth: '10px', width: '100%' }}>{falseCount}</td>
+                            </tr>
+                          </tbody>
+                        </Table>
                       </td>
-                      <td style={{ border: 'none', verticalAlign: 'top', borderRight: '1px solid lightgrey' }}>
-                        <tr>
-                          <td className="text-start" style={{ minWidth: '180px', border: 'none' }}>
-                            Period Start Date:
-                          </td>
-                          <td data-testid={'test-comp-start-date'} style={{ minWidth: '130px', width: '100%', border: 'none' }}>{startDate}</td>
-                        </tr>
-                        <tr>
-                          <td className="text-start" style={{ minWidth: '180px', border: 'none' }}>
-                            Period End Date:
-                          </td>
-                          <td data-testid={'test-comp-end-date'} style={{ minWidth: '130px', width: '100%', border: 'none' }}>{endDate}</td>
-                        </tr>
-                        <tr>
-                          <td className="text-start" style={{ minWidth: '180px', border: 'none' }}>
-                            Comparison Date:
-                          </td>
-                          <td data-testid={'test-comp-now-date'} style={{ minWidth: '130px', width: '100%', border: 'none' }}>{getNow()}</td>
-                        </tr>
+                      <td style={{ borderRight: '1px solid lightgrey', borderBottom: 'none' }}>
+                        <Table size='sm' borderless>
+                          <tbody>
+                            <tr>
+                              <td className="text-start" style={{ minWidth: '180px' }}>
+                                Period Start Date:
+                              </td>
+                              <td data-testid={'test-comp-start-date'} style={{ minWidth: '130px', width: '100%' }}>{startDate}</td>
+                            </tr>
+                            <tr>
+                              <td className="text-start" style={{ minWidth: '180px' }}>
+                                Period End Date:
+                              </td>
+                              <td data-testid={'test-comp-end-date'} style={{ minWidth: '130px', width: '100%' }}>{endDate}</td>
+                            </tr>
+                            <tr>
+                              <td className="text-start" style={{ minWidth: '180px' }}>
+                                Comparison Date:
+                              </td>
+                              <td data-testid={'test-comp-now-date'} style={{ minWidth: '130px', width: '100%' }}>{getNow()}</td>
+                            </tr>
+                          </tbody>
+                        </Table>
                       </td>
-                      <td style={{ border: 'none', verticalAlign: 'top' }}>
-                        <tr>
-                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
-                            Knowledge Repository:
-                          </td>
-                          <td data-testid={'test-comp-knowledge-repo-server'} style={{ width: '100%', border: 'none' }}><a href={selectedKnowledgeRepositoryServer?.baseUrl}>{selectedKnowledgeRepositoryServer?.baseUrl}</a></td>
-                        </tr>
-                        <tr>
-                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
-                            Data Repository:
-                          </td>
-                          <td data-testid={'test-comp-data-repo-server'} style={{ width: '100%', border: 'none' }}><a href={selectedDataRepoServer?.baseUrl}>{selectedDataRepoServer?.baseUrl}</a></td>
-                        </tr>
-                        <tr>
-                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
-                            Measure Evaluation:
-                          </td>
-                          <td data-testid={'test-comp-measure-eval-server'} style={{ width: '100%', border: 'none' }}><a href={selectedMeasureEvaluationServer?.baseUrl}>{selectedMeasureEvaluationServer?.baseUrl}</a></td>
-                        </tr>
+                      <td style={{ borderBottom: 'none' }}>
+                        <Table size='sm' borderless>
+                          <tbody>
+                            <tr>
+                              <td className="text-start" style={{ minWidth: '215px' }}>
+                                Knowledge Repository:
+                              </td>
+                              <td data-testid={'test-comp-knowledge-repo-server'} style={{ width: '100%' }}><a href={selectedKnowledgeRepositoryServer?.baseUrl}>{selectedKnowledgeRepositoryServer?.baseUrl}</a></td>
+                            </tr>
+                            <tr>
+                              <td className="text-start" style={{ minWidth: '215px' }}>
+                                Data Repository:
+                              </td>
+                              <td data-testid={'test-comp-data-repo-server'} style={{ width: '100%' }}><a href={selectedDataRepoServer?.baseUrl}>{selectedDataRepoServer?.baseUrl}</a></td>
+                            </tr>
+                            <tr>
+                              <td className="text-start" style={{ minWidth: '215px' }}>
+                                Measure Evaluation:
+                              </td>
+                              <td data-testid={'test-comp-measure-eval-server'} style={{ width: '100%' }}><a href={selectedMeasureEvaluationServer?.baseUrl}>{selectedMeasureEvaluationServer?.baseUrl}</a></td>
+                            </tr>
+                          </tbody>
+                        </Table>
                       </td>
                     </tr>
                   </tbody>
                 </Table>
               </div>
 
-
             ) : (
-
-
 
               <div>
                 {Constants.testComparisonInstruction}
@@ -271,14 +280,14 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
               .map(([key, value]) => (
                 value.fetchedMeasureReportGroups.length > 0 && value.fetchedEvaluatedMeasureGroups.length > 0 ? (
 
-                  <Table size='sm' className="table" key={key.display + key.id} style={{ width: '100%', border: '1px solid lightgrey', marginBottom: '25px' }}>
+                  <Table size='sm' className="table" key={key.display + key.id} style={{ width: '100%', border: '1px solid lightgrey', marginBottom: '0px' }}>
                     <thead style={{ background: '#F7F7F7', border: '1px solid lightgrey' }}>
                       <tr>
-                        <th style={{ width: '50%', textAlign: 'left', border: 'none', padding: '10px' }}>
+                        <th style={{ width: '50%', textAlign: 'left',  padding: '10px' }}>
                           <h5 data-testid={'test-comp-patient-display' + convertToID(key.id)}>{key.display}</h5>
                           <h6 data-testid={'test-comp-patient-id' + convertToID(key.id)}>ID: {key.id}</h6>
                         </th>
-                        <th style={{ width: '50%', textAlign: 'left', border: 'none', padding: '10px' }}>
+                        <th style={{ width: '50%', textAlign: 'left',  padding: '10px' }}>
                           <h6>Comparison Result:</h6>
                           <h5 data-testid={'test-comp-result-' + convertToID(key.id)} className={`${value.discrepancyExists ? 'text-danger' : 'text-success'}`}>
                             {value.discrepancyExists ? 'Discrepancy' : 'Match'}
@@ -286,45 +295,64 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                         </th>
                       </tr>
                     </thead>
-                    <tbody style={{ border: 'none' }}>
+                    <tbody>
                       <tr>
-                        <td style={{ padding: '8px', border: 'none' }}>
-                          <a target='_blank' rel='noreferrer' href={value.evaluatedMeasureURL}>
-                            <h6>This Evaluation: </h6>
-                          </a>
-                          {value.fetchedEvaluatedMeasureGroups.map((group, index) => (
-                            // mark text in bold if discrepancy exists for this field
-                            <tr key={index} className={`${group.discrepancy && 'fw-bold'}`}>
-                              <td style={{ width: '100%' }} data-testid={'test-comp-this-eval-group-code-' + index}>{group.code.coding[0].code}</td>
-                              <td style={{ width: '100%' }} data-testid={'test-comp-this-eval-group-count-' + index}>{group.count}</td>
-                            </tr>
-                          ))}
-                          <tr>
-                            <td style={{ width: '100%' }} >
-                            <div style={{ fontSize: '11px' }}>
-                                {value.evaluatedMeasureURL}
-                              </div>
-                            </td>
-                          </tr>
+                        <td style={{ padding: '8px' }}>
+                          <Table size='sm' borderless>
+                            <thead>
+                              <tr>
+                                <th>
+                                  <a target='_blank' rel='noreferrer' href={value.evaluatedMeasureURL}>
+                                    <h6>This Evaluation: </h6>
+                                  </a>
+                                </th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {value.fetchedEvaluatedMeasureGroups.map((group, index) => (
+                                // mark text in bold if discrepancy exists for this field
+                                <tr style={{ border: '1px solid lightgrey' }} key={index} className={group.discrepancy ? 'fw-bold' : ''}>
+                                  <td style={{ width: '100%', paddingLeft: '10px'}} data-testid={'test-comp-this-eval-group-code-' + index}>{group.code.coding[0].code}</td>
+                                  <td style={{ width: '100%', paddingRight: '15px' }} data-testid={'test-comp-this-eval-group-count-' + index}>{group.count}</td>
+                                </tr>
+                              ))}
+                              <tr>
+                                <td style={{ width: '100%' }} >
+                                  <div style={{ fontSize: '11px' }}>
+                                    {value.evaluatedMeasureURL}
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </Table>
                         </td>
-
-                        <td style={{ padding: '8px', border: 'none' }}>
-                          <a target='_blank' rel='noreferrer' href={value.measureReportURL}>
-                            <h6>Previous Measure Report:</h6>
-                          </a>
-                          {value.fetchedMeasureReportGroups.map((group, index) => (
-                            <tr key={index} className={`${group.discrepancy && 'fw-bold'}`}>
-                              <td style={{ width: '100%' }} data-testid={'test-comp-prev-eval-group-code-' + index}>{group.code.coding[0].code}</td>
-                              <td style={{ width: '100%' }} data-testid={'test-comp-prev-eval-group-count-' + index}>{group.count}</td>
-                            </tr>
-                          ))}
-                          <tr>
-                            <td style={{ width: '100%' }} >
-                              <div style={{ fontSize: '11px' }}>
-                                {value.measureReportURL}
-                              </div>
-                            </td>
-                          </tr>
+                        <td style={{ padding: '8px' }}>
+                          <Table size='sm' borderless>
+                            <thead>
+                              <tr>
+                                <th>
+                                  <a target='_blank' rel='noreferrer' href={value.measureReportURL}>
+                                    <h6>Previous Measure Report:</h6>
+                                  </a>
+                                </th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {value.fetchedMeasureReportGroups.map((group, index) => (
+                                <tr style={{ border: '1px solid lightgrey'}} key={index} className={group.discrepancy ? 'fw-bold' : ''}>
+                                  <td style={{ width: '100%', paddingLeft: '10px' }} data-testid={'test-comp-prev-eval-group-code-' + index}>{group.code.coding[0].code}</td>
+                                  <td style={{ width: '100%', paddingRight: '15px' }} data-testid={'test-comp-prev-eval-group-count-' + index}>{group.count}</td>
+                                </tr>
+                              ))}
+                              <tr>
+                                <td style={{ width: '100%' }} >
+                                  <div style={{ fontSize: '11px' }}>
+                                    {value.measureReportURL}
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </Table>
                         </td>
                       </tr>
                     </tbody>

--- a/src/components/TestingComparator.tsx
+++ b/src/components/TestingComparator.tsx
@@ -6,6 +6,8 @@ import ReactToPrint from 'react-to-print';
 import { Constants } from '../constants/Constants';
 import { Patient } from '../models/Patient';
 import { MeasureComparisonManager } from '../utils/MeasureComparisonManager';
+import { PatientGroup } from '../models/PatientGroup';
+import { Server } from '../models/Server';
 
 
 interface props {
@@ -16,6 +18,11 @@ interface props {
   loading: boolean;
   startDate: string;
   endDate: string;
+  selectedPatientGroup: PatientGroup | undefined;
+  selectedDataRepoServer: Server | undefined;
+  selectedMeasureEvaluationServer: Server | undefined;
+  selectedMeasure: string | undefined;
+  selectedKnowledgeRepositoryServer: Server | undefined;
 }
 
 /**
@@ -38,7 +45,12 @@ interface props {
  * @returns 
  */
 const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompare, items,
-  compareTestResults, loading, startDate, endDate }) => {
+  compareTestResults, loading, startDate, endDate, selectedPatientGroup, selectedDataRepoServer,
+  selectedMeasureEvaluationServer, selectedMeasure, selectedKnowledgeRepositoryServer }) => {
+
+
+  const requiredDataPresent = selectedPatientGroup && selectedDataRepoServer && selectedMeasureEvaluationServer && selectedMeasure && selectedKnowledgeRepositoryServer;
+
   const convertToID = (str: any | undefined): string => {
     let strIn: string = '' + str;
     return (strIn.replace(' ', ''));
@@ -180,8 +192,47 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
 
 
             ) : (
+
+
+
               <div>
-                <p>{Constants.testComparisonInstruction}</p>
+                {Constants.testComparisonInstruction}
+                <br></br>
+                <br></br>
+                <ul style={{ listStyleType: 'none', paddingLeft: 0 }}>
+
+                  {/* Measure */}
+                  <li>
+                    {selectedMeasure ? '☑' : '☐'} Measure
+                    {selectedMeasure && (
+                      <span> <a target='_blank' href={selectedKnowledgeRepositoryServer?.baseUrl + 'Measure/' + selectedMeasure}>({selectedMeasure})</a></span>
+                    )}
+                  </li>
+
+                  {/* Data Repository Server */}
+                  <li>
+                    {selectedDataRepoServer?.baseUrl ? '☑' : '☐'} Data Repository Server
+                    {selectedDataRepoServer?.baseUrl && (
+                      <span> <a target='_blank' href={selectedDataRepoServer?.baseUrl}>({selectedDataRepoServer.baseUrl})</a></span>
+                    )}
+                  </li>
+
+                  {/* Patient Group */}
+                  <li>
+                    {selectedPatientGroup ? '☑' : '☐'} Patient Group
+                    {selectedDataRepoServer?.baseUrl && (
+                      <span> <a target='_blank' href={selectedDataRepoServer?.baseUrl + 'Group/' + selectedPatientGroup?.id}>(Group/{selectedPatientGroup?.id})</a></span>
+                    )}
+                  </li>
+
+                  {/* Measure Evaluation Server */}
+                  <li>
+                    {selectedMeasureEvaluationServer?.baseUrl ? '☑' : '☐'} Measure Evaluation Server
+                    {selectedMeasureEvaluationServer?.baseUrl && (
+                      <span> <a target='_blank' href={selectedMeasureEvaluationServer?.baseUrl}>({selectedMeasureEvaluationServer.baseUrl})</a></span>
+                    )}
+                  </li>
+                </ul>
               </div>
             )}
             {/* Sort array by discrepancy so matches are bottom of list. Convert boolean to 1/0, compare by basic int: */}
@@ -291,7 +342,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                   data-testid='test-compare-collect-data-button'
                   className='w-100 btn btn-primary btn-lg'
                   id='evaluate'
-                  disabled={loading}
+                  disabled={loading || !requiredDataPresent}
                   onClick={(e) => compareTestResults()}
                 >
                   Generate Test Comparison Summary</Button>

--- a/src/components/TestingComparator.tsx
+++ b/src/components/TestingComparator.tsx
@@ -205,7 +205,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                   <li>
                     {selectedMeasure ? '☑' : '☐'} Measure
                     {selectedKnowledgeRepositoryServer?.baseUrl && selectedMeasure && (
-                      <span> <a target='_blank' href={selectedKnowledgeRepositoryServer?.baseUrl + 'Measure/' + selectedMeasure}>({selectedMeasure})</a></span>
+                      <span> <a target='_blank' rel='noreferrer' href={selectedKnowledgeRepositoryServer?.baseUrl + 'Measure/' + selectedMeasure}>({selectedMeasure})</a></span>
                     )}
                   </li>
 
@@ -213,7 +213,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                   <li>
                     {selectedDataRepoServer?.baseUrl ? '☑' : '☐'} Data Repository Server
                     {selectedDataRepoServer?.baseUrl && (
-                      <span> <a target='_blank' href={selectedDataRepoServer?.baseUrl}>({selectedDataRepoServer.baseUrl})</a></span>
+                      <span> <a target='_blank' rel='noreferrer' href={selectedDataRepoServer?.baseUrl}>({selectedDataRepoServer.baseUrl})</a></span>
                     )}
                   </li>
 
@@ -221,7 +221,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                   <li>
                     {selectedPatientGroup?.id ? '☑' : '☐'} Patient Group
                     {selectedPatientGroup?.id && selectedDataRepoServer?.baseUrl && (
-                      <span> <a target='_blank' href={selectedDataRepoServer?.baseUrl + 'Group/' + selectedPatientGroup?.id}>(Group/{selectedPatientGroup?.id})</a></span>
+                      <span> <a target='_blank' rel='noreferrer' href={selectedDataRepoServer?.baseUrl + 'Group/' + selectedPatientGroup?.id}>(Group/{selectedPatientGroup?.id})</a></span>
                     )}
                   </li>
 
@@ -229,7 +229,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                   <li>
                     {selectedMeasureEvaluationServer?.baseUrl ? '☑' : '☐'} Measure Evaluation Server
                     {selectedMeasureEvaluationServer?.baseUrl && (
-                      <span> <a target='_blank' href={selectedMeasureEvaluationServer?.baseUrl}>({selectedMeasureEvaluationServer.baseUrl})</a></span>
+                      <span> <a target='_blank' rel='noreferrer' href={selectedMeasureEvaluationServer?.baseUrl}>({selectedMeasureEvaluationServer.baseUrl})</a></span>
                     )}
                   </li>
                 </ul>
@@ -271,7 +271,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                     <tbody>
                       <tr>
                         <td style={{ width: '50%', border: 'none' }}>
-                          <a target='_blank' href={value.evaluatedMeasureURL}>
+                          <a target='_blank' rel='noreferrer' href={value.evaluatedMeasureURL}>
                             <h6>This Evaluation: </h6>
                           </a>
                           <table className="table" style={{ border: '1px solid lightgrey' }}>
@@ -288,7 +288,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                         </td>
 
                         <td style={{ width: '50%' }}>
-                          <a target='_blank' href={value.measureReportURL}>
+                          <a target='_blank' rel='noreferrer' href={value.measureReportURL}>
                             <h6>Previous Measure Report:</h6>
                           </a>
                           <table className="table" style={{ border: '1px solid lightgrey' }}>

--- a/src/components/TestingComparator.tsx
+++ b/src/components/TestingComparator.tsx
@@ -127,7 +127,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
             {items.size > 0 ? (
 
               <div>
-                <Table style={{ width: '100%', border: 'none' }}>
+                <Table style={{ width: '100%', border: 'none', margin: '0' }}>
                   <thead>
                     <tr>
                       <th colSpan={2} className="text-center">
@@ -245,7 +245,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
               .map(([key, value]) => (
                 value.fetchedMeasureReportGroups.length > 0 && value.fetchedEvaluatedMeasureGroups.length > 0 ? (
 
-                  <table className="table mt-4" key={key.display + key.id} style={{ width: '100%', border: '2px solid lightgrey' }}>
+                  <table className="table" key={key.display + key.id} style={{ width: '100%', border: '1px solid lightgrey', margin: '0px' }}>
                     <thead>
                       <tr>
                         <th colSpan={2}>

--- a/src/components/TestingComparator.tsx
+++ b/src/components/TestingComparator.tsx
@@ -8,6 +8,7 @@ import { Patient } from '../models/Patient';
 import { MeasureComparisonManager } from '../utils/MeasureComparisonManager';
 import { PatientGroup } from '../models/PatientGroup';
 import { Server } from '../models/Server';
+import { PatientGroupUtils } from '../utils/PatientGroupUtils';
 
 
 interface props {
@@ -23,6 +24,7 @@ interface props {
   selectedMeasureEvaluationServer: Server | undefined;
   selectedMeasure: string | undefined;
   selectedKnowledgeRepositoryServer: Server | undefined;
+  selectedPatient: Patient | undefined;
 }
 
 /**
@@ -46,7 +48,7 @@ interface props {
  */
 const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompare, items,
   compareTestResults, loading, startDate, endDate, selectedPatientGroup, selectedDataRepoServer,
-  selectedMeasureEvaluationServer, selectedMeasure, selectedKnowledgeRepositoryServer }) => {
+  selectedMeasureEvaluationServer, selectedMeasure, selectedKnowledgeRepositoryServer, selectedPatient }) => {
 
 
   const requiredDataPresent = selectedPatientGroup && selectedDataRepoServer && selectedMeasureEvaluationServer && selectedMeasure && selectedKnowledgeRepositoryServer;
@@ -83,6 +85,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
     const formattedDate = today.toISOString().split('T')[0];
     return formattedDate;
   }
+
 
   return (
 
@@ -127,63 +130,75 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
             {items.size > 0 ? (
 
               <div>
-                <Table style={{ width: '100%', border: 'none', margin: '0' }}>
-                  <thead>
+                <Table size='sm' >
+                  <thead className="text-center">
                     <tr>
-                      <th colSpan={2} className="text-center">
+                      <th colSpan={3} style={{ width: '100%', border: 'none', padding: '0px' }}>
                         <h5 data-testid={'test-comp-title'}>{title}</h5>
                       </th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td style={{ width: '50%', border: 'none', verticalAlign: 'top' }}>
-                        <Table style={{ width: '100%', border: 'none' }}>
-                          <tbody>
-                            <tr>
-                              <td className="text-start" style={{ minWidth: '200px', border: 'none' }}>
-                                Patients Evaluated:
-                              </td>
-                              <td data-testid={'test-comp-pat-eval-count'} style={{ width: '100%', border: 'none' }}>{items.size}</td>
-                            </tr>
-                            <tr>
-                              <td className="text-start" style={{ minWidth: '200px', border: 'none' }}>
-                                Discrepancies Found:
-                              </td>
-                              <td data-testid={'test-comp-disc-found-count'} style={{ width: '100%', border: 'none' }}>{trueCount}</td>
-                            </tr>
-                            <tr>
-                              <td className="text-start" style={{ minWidth: '200px', border: 'none' }}>
-                                Matching Data Found:
-                              </td>
-                              <td data-testid={'test-comp-match-count'} style={{ width: '100%', border: 'none' }}>{falseCount}</td>
-                            </tr>
-                          </tbody>
-                        </Table>
+                      <td style={{ border: 'none', verticalAlign: 'top', borderRight: '1px solid lightgrey' }}>
+                        <tr>
+                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
+                            Patients Evaluated:
+                          </td>
+                          <td data-testid={'test-comp-pat-eval-count'} style={{ minWidth: '10px', width: '100%', border: 'none' }}>{items.size}</td>
+                        </tr>
+                        <tr>
+                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
+                            Discrepancies Found:
+                          </td>
+                          <td data-testid={'test-comp-disc-found-count'} style={{ minWidth: '10px', width: '100%', border: 'none' }}>{trueCount}</td>
+                        </tr>
+                        <tr>
+                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
+                            Matching Data Found:
+                          </td>
+                          <td data-testid={'test-comp-match-count'} style={{ minWidth: '10px', width: '100%', border: 'none' }}>{falseCount}</td>
+                        </tr>
                       </td>
-                      <td style={{ width: '50%', border: 'none', verticalAlign: 'top' }}>
-                        <Table style={{ width: '100%', border: 'none' }}>
-                          <tbody>
-                            <tr>
-                              <td className="text-start" style={{ minWidth: '200px', border: 'none' }}>
-                                Period Start Date:
-                              </td>
-                              <td data-testid={'test-comp-start-date'} style={{ width: '100%', border: 'none' }}>{startDate}</td>
-                            </tr>
-                            <tr>
-                              <td className="text-start" style={{ minWidth: '200px', border: 'none' }}>
-                                Period End Date:
-                              </td>
-                              <td data-testid={'test-comp-end-date'} style={{ width: '100%', border: 'none' }}>{endDate}</td>
-                            </tr>
-                            <tr>
-                              <td className="text-start" style={{ minWidth: '200px', border: 'none' }}>
-                                Comparison Date:
-                              </td>
-                              <td data-testid={'test-comp-now-date'} style={{ width: '100%', border: 'none' }}>{getNow()}</td>
-                            </tr>
-                          </tbody>
-                        </Table>
+                      <td style={{ border: 'none', verticalAlign: 'top', borderRight: '1px solid lightgrey' }}>
+                        <tr>
+                          <td className="text-start" style={{ minWidth: '180px', border: 'none' }}>
+                            Period Start Date:
+                          </td>
+                          <td data-testid={'test-comp-start-date'} style={{ minWidth: '130px', width: '100%', border: 'none' }}>{startDate}</td>
+                        </tr>
+                        <tr>
+                          <td className="text-start" style={{ minWidth: '180px', border: 'none' }}>
+                            Period End Date:
+                          </td>
+                          <td data-testid={'test-comp-end-date'} style={{ minWidth: '130px', width: '100%', border: 'none' }}>{endDate}</td>
+                        </tr>
+                        <tr>
+                          <td className="text-start" style={{ minWidth: '180px', border: 'none' }}>
+                            Comparison Date:
+                          </td>
+                          <td data-testid={'test-comp-now-date'} style={{ minWidth: '130px', width: '100%', border: 'none' }}>{getNow()}</td>
+                        </tr>
+                      </td>
+                      <td style={{ border: 'none', verticalAlign: 'top' }}>
+                        <tr>
+                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
+                            Knowledge Repository:
+                          </td>
+                          <td data-testid={'test-comp-knowledge-repo-server'} style={{ width: '100%', border: 'none' }}><a href={selectedKnowledgeRepositoryServer?.baseUrl}>{selectedKnowledgeRepositoryServer?.baseUrl}</a></td>
+                        </tr>
+                        <tr>
+                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
+                            Data Repository:
+                          </td>
+                          <td data-testid={'test-comp-data-repo-server'} style={{ width: '100%', border: 'none' }}><a href={selectedDataRepoServer?.baseUrl}>{selectedDataRepoServer?.baseUrl}</a></td>
+                        </tr>
+                        <tr>
+                          <td className="text-start" style={{ minWidth: '215px', border: 'none' }}>
+                            Measure Evaluation:
+                          </td>
+                          <td data-testid={'test-comp-measure-eval-server'} style={{ width: '100%', border: 'none' }}><a href={selectedMeasureEvaluationServer?.baseUrl}>{selectedMeasureEvaluationServer?.baseUrl}</a></td>
+                        </tr>
                       </td>
                     </tr>
                   </tbody>
@@ -225,6 +240,17 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                     )}
                   </li>
 
+                  {PatientGroupUtils.patientExistsInGroup(selectedPatient, selectedPatientGroup) &&
+                    <ul style={{ listStyleType: 'none', paddingLeft: '20px' }}>
+                      <li>
+                        {selectedPatient?.id ? '☑' : '☐'} {'Patient (exists in Group)'}
+                        {selectedPatient?.id && selectedDataRepoServer?.baseUrl && (
+                          <span> <a target='_blank' rel='noreferrer' href={selectedDataRepoServer?.baseUrl + 'Patient/' + selectedPatient?.id}>(Patient/{selectedPatient?.id})</a></span>
+                        )}
+                      </li>
+                    </ul>
+                  }
+
                   {/* Measure Evaluation Server */}
                   <li>
                     {selectedMeasureEvaluationServer?.baseUrl ? '☑' : '☐'} Measure Evaluation Server
@@ -245,66 +271,65 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
               .map(([key, value]) => (
                 value.fetchedMeasureReportGroups.length > 0 && value.fetchedEvaluatedMeasureGroups.length > 0 ? (
 
-                  <table className="table" key={key.display + key.id} style={{ width: '100%', border: '1px solid lightgrey', margin: '0px'}}>
-                    <thead>
+                  <Table size='sm' className="table" key={key.display + key.id} style={{ width: '100%', border: '1px solid lightgrey', marginBottom: '25px' }}>
+                    <thead style={{ background: '#F7F7F7', border: '1px solid lightgrey' }}>
                       <tr>
-                        <th colSpan={2}>
-                          <table style={{ width: '100%', background: '#F7F7F7', borderCollapse: 'collapse', border: 'none', colorAdjust: 'exact' }}>
-                            <thead>
-                              <tr>
-                                <th style={{ width: '50%', textAlign: 'left', border: 'none' }}>
-                                  <h5 data-testid={'test-comp-patient-display' + convertToID(key.id)}>{key.display}</h5>
-                                  <h6 data-testid={'test-comp-patient-id' + convertToID(key.id)}>ID: {key.id}</h6>
-                                </th>
-                                <th style={{ width: '50%', textAlign: 'left', border: 'none' }}>
-                                  <h6>Comparison Result:</h6>
-                                  <h5 data-testid={'test-comp-result-' + convertToID(key.id)} className={`${value.discrepancyExists ? 'text-danger' : 'text-success'}`}>
-                                    {value.discrepancyExists ? 'Discrepancy' : 'Match'}
-                                  </h5>
-                                </th>
-                              </tr>
-                            </thead>
-                          </table>
+                        <th style={{ width: '50%', textAlign: 'left', border: 'none', padding: '10px' }}>
+                          <h5 data-testid={'test-comp-patient-display' + convertToID(key.id)}>{key.display}</h5>
+                          <h6 data-testid={'test-comp-patient-id' + convertToID(key.id)}>ID: {key.id}</h6>
+                        </th>
+                        <th style={{ width: '50%', textAlign: 'left', border: 'none', padding: '10px' }}>
+                          <h6>Comparison Result:</h6>
+                          <h5 data-testid={'test-comp-result-' + convertToID(key.id)} className={`${value.discrepancyExists ? 'text-danger' : 'text-success'}`}>
+                            {value.discrepancyExists ? 'Discrepancy' : 'Match'}
+                          </h5>
                         </th>
                       </tr>
                     </thead>
-                    <tbody>
+                    <tbody style={{ border: 'none' }}>
                       <tr>
-                        <td style={{ width: '50%', border: 'none' }}>
+                        <td style={{ padding: '8px', border: 'none' }}>
                           <a target='_blank' rel='noreferrer' href={value.evaluatedMeasureURL}>
                             <h6>This Evaluation: </h6>
                           </a>
-                          <table className="table" style={{ border: '1px solid lightgrey' }}>
-                            <tbody>
-                              {value.fetchedEvaluatedMeasureGroups.map((group, index) => (
-                                // mark text in bold if discrepancy exists for this field
-                                <tr key={index} className={`${group.discrepancy && 'fw-bold'}`}>
-                                  <td data-testid={'test-comp-this-eval-group-code-' + index}>{group.code.coding[0].code}</td>
-                                  <td data-testid={'test-comp-this-eval-group-count-' + index}>{group.count}</td>
-                                </tr>
-                              ))}
-                            </tbody>
-                          </table>
+                          {value.fetchedEvaluatedMeasureGroups.map((group, index) => (
+                            // mark text in bold if discrepancy exists for this field
+                            <tr key={index} className={`${group.discrepancy && 'fw-bold'}`}>
+                              <td style={{ width: '100%' }} data-testid={'test-comp-this-eval-group-code-' + index}>{group.code.coding[0].code}</td>
+                              <td style={{ width: '100%' }} data-testid={'test-comp-this-eval-group-count-' + index}>{group.count}</td>
+                            </tr>
+                          ))}
+                          <tr>
+                            <td style={{ width: '100%' }} >
+                            <div style={{ fontSize: '11px' }}>
+                                {value.evaluatedMeasureURL}
+                              </div>
+                            </td>
+                          </tr>
                         </td>
 
-                        <td style={{ width: '50%' }}>
+                        <td style={{ padding: '8px', border: 'none' }}>
                           <a target='_blank' rel='noreferrer' href={value.measureReportURL}>
                             <h6>Previous Measure Report:</h6>
                           </a>
-                          <table className="table" style={{ border: '1px solid lightgrey' }}>
-                            <tbody>
-                              {value.fetchedMeasureReportGroups.map((group, index) => (
-                                <tr key={index} className={`${group.discrepancy && 'fw-bold'}`}>
-                                  <td data-testid={'test-comp-prev-eval-group-code-' + index}>{group.code.coding[0].code}</td>
-                                  <td data-testid={'test-comp-prev-eval-group-count-' + index}>{group.count}</td>
-                                </tr>
-                              ))}
-                            </tbody>
-                          </table>
+                          {value.fetchedMeasureReportGroups.map((group, index) => (
+                            <tr key={index} className={`${group.discrepancy && 'fw-bold'}`}>
+                              <td style={{ width: '100%' }} data-testid={'test-comp-prev-eval-group-code-' + index}>{group.code.coding[0].code}</td>
+                              <td style={{ width: '100%' }} data-testid={'test-comp-prev-eval-group-count-' + index}>{group.count}</td>
+                            </tr>
+                          ))}
+                          <tr>
+                            <td style={{ width: '100%' }} >
+                              <div style={{ fontSize: '11px' }}>
+                                {value.measureReportURL}
+                              </div>
+                            </td>
+                          </tr>
                         </td>
                       </tr>
                     </tbody>
-                  </table>
+
+                  </Table>
 
                 ) : (
                   <div key={key.display + key.id}>

--- a/src/components/TestingComparator.tsx
+++ b/src/components/TestingComparator.tsx
@@ -204,7 +204,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                   {/* Measure */}
                   <li>
                     {selectedMeasure ? '☑' : '☐'} Measure
-                    {selectedMeasure && (
+                    {selectedKnowledgeRepositoryServer?.baseUrl && selectedMeasure && (
                       <span> <a target='_blank' href={selectedKnowledgeRepositoryServer?.baseUrl + 'Measure/' + selectedMeasure}>({selectedMeasure})</a></span>
                     )}
                   </li>
@@ -219,8 +219,8 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
 
                   {/* Patient Group */}
                   <li>
-                    {selectedPatientGroup ? '☑' : '☐'} Patient Group
-                    {selectedDataRepoServer?.baseUrl && (
+                    {selectedPatientGroup?.id ? '☑' : '☐'} Patient Group
+                    {selectedPatientGroup?.id && selectedDataRepoServer?.baseUrl && (
                       <span> <a target='_blank' href={selectedDataRepoServer?.baseUrl + 'Group/' + selectedPatientGroup?.id}>(Group/{selectedPatientGroup?.id})</a></span>
                     )}
                   </li>

--- a/src/components/TestingComparator.tsx
+++ b/src/components/TestingComparator.tsx
@@ -131,7 +131,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                   <thead>
                     <tr>
                       <th colSpan={2} className="text-center">
-                        <h4 data-testid={'test-comp-title'}>{title}</h4>
+                        <h5 data-testid={'test-comp-title'}>{title}</h5>
                       </th>
                     </tr>
                   </thead>
@@ -245,7 +245,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
               .map(([key, value]) => (
                 value.fetchedMeasureReportGroups.length > 0 && value.fetchedEvaluatedMeasureGroups.length > 0 ? (
 
-                  <table className="table" key={key.display + key.id} style={{ width: '100%', border: '1px solid lightgrey', margin: '0px' }}>
+                  <table className="table" key={key.display + key.id} style={{ width: '100%', border: '1px solid lightgrey', margin: '0px'}}>
                     <thead>
                       <tr>
                         <th colSpan={2}>
@@ -253,14 +253,14 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                             <thead>
                               <tr>
                                 <th style={{ width: '50%', textAlign: 'left', border: 'none' }}>
-                                  <h4 data-testid={'test-comp-patient-display' + convertToID(key.id)}>{key.display}</h4>
+                                  <h5 data-testid={'test-comp-patient-display' + convertToID(key.id)}>{key.display}</h5>
                                   <h6 data-testid={'test-comp-patient-id' + convertToID(key.id)}>ID: {key.id}</h6>
                                 </th>
                                 <th style={{ width: '50%', textAlign: 'left', border: 'none' }}>
                                   <h6>Comparison Result:</h6>
-                                  <h3 data-testid={'test-comp-result-' + convertToID(key.id)} className={`${value.discrepancyExists ? 'text-danger' : 'text-success'}`}>
+                                  <h5 data-testid={'test-comp-result-' + convertToID(key.id)} className={`${value.discrepancyExists ? 'text-danger' : 'text-success'}`}>
                                     {value.discrepancyExists ? 'Discrepancy' : 'Match'}
-                                  </h3>
+                                  </h5>
                                 </th>
                               </tr>
                             </thead>

--- a/src/components/TestingComparator.tsx
+++ b/src/components/TestingComparator.tsx
@@ -226,7 +226,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                 <ul style={{ listStyleType: 'none', paddingLeft: 0 }}>
 
                   {/* Measure */}
-                  <li>
+                  <li data-testid='test-compare-checklist-measure'>
                     {selectedMeasure ? '☑' : '☐'} Measure
                     {selectedKnowledgeRepositoryServer?.baseUrl && selectedMeasure && (
                       <span> <a target='_blank' rel='noreferrer' href={selectedKnowledgeRepositoryServer?.baseUrl + 'Measure/' + selectedMeasure}>({selectedMeasure})</a></span>
@@ -234,7 +234,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                   </li>
 
                   {/* Data Repository Server */}
-                  <li>
+                  <li  data-testid='test-compare-checklist-data-repo-server'>
                     {selectedDataRepoServer?.baseUrl ? '☑' : '☐'} Data Repository Server
                     {selectedDataRepoServer?.baseUrl && (
                       <span> <a target='_blank' rel='noreferrer' href={selectedDataRepoServer?.baseUrl}>({selectedDataRepoServer.baseUrl})</a></span>
@@ -242,7 +242,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                   </li>
 
                   {/* Patient Group */}
-                  <li>
+                  <li data-testid='test-compare-checklist-patient-group'>
                     {selectedPatientGroup?.id ? '☑' : '☐'} Patient Group
                     {selectedPatientGroup?.id && selectedDataRepoServer?.baseUrl && (
                       <span> <a target='_blank' rel='noreferrer' href={selectedDataRepoServer?.baseUrl + 'Group/' + selectedPatientGroup?.id}>(Group/{selectedPatientGroup?.id})</a></span>
@@ -261,7 +261,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                   }
 
                   {/* Measure Evaluation Server */}
-                  <li>
+                  <li data-testid='test-compare-checklist-measure-eval-server'>
                     {selectedMeasureEvaluationServer?.baseUrl ? '☑' : '☐'} Measure Evaluation Server
                     {selectedMeasureEvaluationServer?.baseUrl && (
                       <span> <a target='_blank' rel='noreferrer' href={selectedMeasureEvaluationServer?.baseUrl}>({selectedMeasureEvaluationServer.baseUrl})</a></span>
@@ -380,7 +380,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
             <div className='col-md-5 order-md-2'>
               <br />
               {loading ? (
-                <Button data-testid='test-compare-collect-data-button-spinner' className='w-100 btn btn-primary btn-lg' id='evaluate' disabled={loading}>
+                <Button data-testid='test-compare-generate-summary-button-spinner' className='w-100 btn btn-primary btn-lg' id='evaluate' disabled={loading}>
                   <Spinner
                     as='span'
                     variant='light'
@@ -392,7 +392,7 @@ const TestingComparator: React.FC<props> = ({ showTestCompare, setShowTestCompar
                 </Button>
               ) : (
                 <Button
-                  data-testid='test-compare-collect-data-button'
+                  data-testid='test-compare-generate-summary-button'
                   className='w-100 btn btn-primary btn-lg'
                   id='evaluate'
                   disabled={loading || !requiredDataPresent}

--- a/src/constants/Constants.ts
+++ b/src/constants/Constants.ts
@@ -21,10 +21,7 @@ export class Constants {
     public static readonly error_selectReceivingSystemServer = 'Please select a Data Repository server to use';
     public static readonly error_selectMeasureToSubmit = 'Please select a Measure to collect the data for';
 
-    // public static readonly evaluateMeasureFetchURL = '{0}Measure/{1}/$evaluate-measure?periodStart={2}&periodEnd={3}&reportType=subject-list';
-    // public static readonly evaluateMeasureWithSubjectFetchURL = '{0}Measure/{1}/$evaluate-measure?subject={2}&periodStart={3}&periodEnd={4}';
-    //GET /Measure/$evaluate-measure?subject=Group/example-group&measure=Measure/your-measure-id&periodStart=2023-01-01&periodEnd=2023-12-31
-    // public static readonly evaluateMeasureWithSubjectFetchURL = '{0}/Measure/$evaluate-measure?subject={1}&measure={2}&periodStart={3}&periodEnd={4}&reportType=subject-list';
+    public static readonly collectDataWithSubjectFetchURL = '{0}Measure/{1}/$collect-data?periodStart={2}&periodEnd={3}&subject={4}&reportType=subject-list';
 
     public static readonly evaluateMeasureWithSubjectFetchURL = '{0}Measure/{1}/$evaluate-measure?periodStart={2}&periodEnd={3}&subject={4}&reportType=subject-list';
 
@@ -41,7 +38,6 @@ export class Constants {
 
     public static readonly groupUrlEnding = 'Group';
 
-
     public static readonly error_selectKnowledgeRepository = 'Please select a Knowledge Repository server to use';
 
     public static readonly dataSubmitted = 'Data Submitted';
@@ -52,7 +48,10 @@ export class Constants {
 
     public static readonly evaluateMeasure_noGroupFound = 'When no Patient is selected, this operation attempts to use Group data. No Patient Group data could be established for the selected Measure. Select an individual Patient from the Patient dropdown and attempt operation again.';
     public static readonly testComparisonInstruction = 'This utility compares real-time Measure evaluations with existing MeasureReports. To begin, select a Measure, select a Data Repository Server for Patient and MeasureReport data, select a Patient (NOTE: for bulk processing of all Patients, leave unselected), and select a Measure Evaluation Server.';
+    
+    public static readonly largeDataNOTE = ' NOTE: Without subject, ALL Patient data is analyzed. Complexity may cause 504 Timeout'
 
+    
     //testing purposes:
     public static readonly serverTestData: Server[] = [
         {

--- a/src/constants/Constants.ts
+++ b/src/constants/Constants.ts
@@ -21,14 +21,12 @@ export class Constants {
     public static readonly error_selectReceivingSystemServer = 'Please select a Data Repository server to use';
     public static readonly error_selectMeasureToSubmit = 'Please select a Measure to collect the data for';
 
-    public static readonly evaluateMeasureFetchURL = '{0}Measure/{1}/$evaluate-measure?periodStart={2}&periodEnd={3}&reportType=subject-list';
-    // public static readonly evaluateMeasureWithPatientFetchURL = '{0}Measure/{1}/$evaluate-measure?periodStart={2}&periodEnd={3}&subject={4}&reportType=subject';
-    public static readonly evaluateMeasureWithPatientFetchURL = '{0}Measure/{1}/$evaluate-measure?subject={2}&periodStart={3}&periodEnd={4}';
+    // public static readonly evaluateMeasureFetchURL = '{0}Measure/{1}/$evaluate-measure?periodStart={2}&periodEnd={3}&reportType=subject-list';
+    // public static readonly evaluateMeasureWithSubjectFetchURL = '{0}Measure/{1}/$evaluate-measure?subject={2}&periodStart={3}&periodEnd={4}';
+    //GET /Measure/$evaluate-measure?subject=Group/example-group&measure=Measure/your-measure-id&periodStart=2023-01-01&periodEnd=2023-12-31
+    // public static readonly evaluateMeasureWithSubjectFetchURL = '{0}/Measure/$evaluate-measure?subject={1}&measure={2}&periodStart={3}&periodEnd={4}&reportType=subject-list';
 
-    // Expected: "http://localhost:8080/1/Measure/selectedMeasure/$evaluate-measure?subject=selectedPatient&periodStart=startDate&periodEnd=endDate"
-    // Received: "http://localhost:8080/1/Measure/selectedMeasure/$evaluate-measure?periodStart=startDate&periodEnd=endDate&subject=selectedPatient&reportType=subject"
-
-
+    public static readonly evaluateMeasureWithSubjectFetchURL = '{0}Measure/{1}/$evaluate-measure?periodStart={2}&periodEnd={3}&subject={4}&reportType=subject-list';
 
     public static readonly measureReportFetchURL_byEvaluatedResource = '{0}MeasureReport?evaluated-resource=Patient/{1}';
     public static readonly measureReportFetchURL_byMeasure = '{0}MeasureReport?evaluated-resource=Patient/{1}&measure=Measure/{2}';
@@ -52,7 +50,7 @@ export class Constants {
     public static readonly measurePosted = 'Measure Posted';
     public static readonly measurePostedFetchDataError = 'There was an error posting the measure';
 
-    public static readonly testCompare_NoGroup = 'No Patient Group files could be established for the selected Measure.';
+    public static readonly evaluateMeasure_noGroupFound = 'When no Patient is selected, this operation attempts to use Group data. No Patient Group data could be established for the selected Measure. Select an individual Patient from the Patient dropdown and attempt operation again.';
     public static readonly testComparisonInstruction = 'This utility compares real-time Measure evaluations with existing MeasureReports. To begin, select a Measure, select a Data Repository Server for Patient and MeasureReport data, select a Patient (NOTE: for bulk processing of all Patients, leave unselected), and select a Measure Evaluation Server.';
 
     //testing purposes:

--- a/src/constants/Constants.ts
+++ b/src/constants/Constants.ts
@@ -47,7 +47,7 @@ export class Constants {
     public static readonly measurePostedFetchDataError = 'There was an error posting the measure';
 
     public static readonly evaluateMeasure_noGroupFound = 'When no Patient is selected, this operation attempts to use Group data. No Patient Group data could be established for the selected Measure. Select an individual Patient from the Patient dropdown and attempt operation again.';
-    public static readonly testComparisonInstruction = 'This utility compares real-time Measure evaluations with existing MeasureReports. To begin, select a Measure, select a Data Repository Server for Patient and MeasureReport data, select a Patient (NOTE: for bulk processing of all Patients, leave unselected), and select a Measure Evaluation Server.';
+    public static readonly testComparisonInstruction = 'This utility compares real-time Measure evaluations with existing MeasureReports and displays a summary of discrepancies and matches. To begin, verify the following items are established:';
     
     public static readonly largeDataNOTE = ' NOTE: Without subject, ALL Patient data is analyzed. Complexity may cause 504 Timeout'
 

--- a/src/data/AbstractDataFetch.tsx
+++ b/src/data/AbstractDataFetch.tsx
@@ -34,6 +34,10 @@ export abstract class AbstractDataFetch {
 
         await fetch(this.getUrl(), this.requestOptions)
             .then((response) => {
+                if (response?.status === 504){
+                    throw new Error('504 (Gateway Timeout)')
+                }
+
                 responseStatusText = response?.statusText;
                 return response.json();
             })
@@ -50,14 +54,6 @@ export abstract class AbstractDataFetch {
         return ret;
     };
 
-    isJsonString = (data: any): boolean => {
-        try {
-            JSON.stringify(data, undefined, 2);
-        } catch (e) {
-            return false;
-        }
-        return true;
-    }
 }
 
 

--- a/src/data/CollectDataFetch.tsx
+++ b/src/data/CollectDataFetch.tsx
@@ -1,8 +1,9 @@
 import { Constants } from '../constants/Constants';
+import { Patient } from '../models/Patient';
+import { PatientGroup } from '../models/PatientGroup';
+import { Server } from '../models/Server';
 import { StringUtils } from '../utils/StringUtils';
 import { AbstractDataFetch, FetchType } from './AbstractDataFetch';
-import {Server} from '../models/Server';
-import { Patient } from '../models/Patient';
 
 export class CollectDataFetch extends AbstractDataFetch {
     type: FetchType;
@@ -12,12 +13,16 @@ export class CollectDataFetch extends AbstractDataFetch {
     startDate: string = '';
     endDate: string = '';
     selectedPatient: Patient | undefined;
+    patientGroup: PatientGroup | undefined;
+    useSubject: boolean = false;
 
     constructor(selectedDataRepo: Server | undefined,
         selectedMeasure: string,
         startDate: string,
         endDate: string,
-        selectedPatient?: Patient) {
+        selectedPatient?: Patient,
+        patientGroup?: PatientGroup | undefined,
+        useSubject?: boolean) {
 
         super();
         this.type = FetchType.COLLECT_DATA;
@@ -38,26 +43,59 @@ export class CollectDataFetch extends AbstractDataFetch {
             throw new Error(StringUtils.format(Constants.missingProperty, 'endDate'));
         }
 
+        if (useSubject) {
+            if (!selectedPatient || selectedPatient.id === '') {
+                if (!patientGroup || patientGroup.id === '') {
+                    throw new Error(StringUtils.format(Constants.missingProperty, 'Patient or Group'));
+                }
+            }
+        }
+
         this.selectedDataRepo = selectedDataRepo;
         this.selectedMeasure = selectedMeasure;
         this.startDate = startDate;
         this.endDate = endDate;
         if (selectedPatient) this.selectedPatient = selectedPatient;
+        if (patientGroup) this.patientGroup = patientGroup;
+        if (useSubject) this.useSubject = useSubject;
+
     }
 
     public getUrl(): string {
-        let ret = this.selectedDataRepo?.baseUrl + 'Measure/' + this.selectedMeasure +
-            '/$collect-data?periodStart=' + this.startDate + '&periodEnd=' + this.endDate;
 
-        if (this.selectedPatient !== undefined && this.selectedPatient.id) {
-            ret = ret + '&subject=' + this.selectedPatient.id;
+        let subject = '';
+        if (this.useSubject) {
+            if (this.selectedPatient?.id) {
+                subject = 'Patient/' + this.selectedPatient.id;
+            } else if (this.patientGroup) {
+                subject = 'Group/' + this.patientGroup.id;
+            }
+            return StringUtils.format(Constants.collectDataWithSubjectFetchURL,
+                this.selectedDataRepo?.baseUrl,
+                this.selectedMeasure,
+                this.startDate,
+                this.endDate,
+                subject
+            );
         }
-        return ret;
+
+        //useSubject not true, return url without subject line
+        return StringUtils.format(Constants.collectDataWithSubjectFetchURL.replace('&subject={4}', ''),
+            this.selectedDataRepo?.baseUrl,
+            this.selectedMeasure,
+            this.startDate,
+            this.endDate
+        );
+
     }
 
     protected processReturnedData(data: any) {
-        const ret: string = JSON.stringify(data, undefined, 2)
-        return ret;
+        try {
+            const ret: string = JSON.stringify(data, undefined, 2)
+            return ret;
+        } catch (error: any) {
+            return data;
+        }
     }
 
 }

--- a/src/data/CollectDataFetch.tsx
+++ b/src/data/CollectDataFetch.tsx
@@ -20,9 +20,10 @@ export class CollectDataFetch extends AbstractDataFetch {
         selectedMeasure: string,
         startDate: string,
         endDate: string,
+        useSubject: boolean,
         selectedPatient?: Patient,
-        patientGroup?: PatientGroup | undefined,
-        useSubject?: boolean) {
+        patientGroup?: PatientGroup | undefined
+    ) {
 
         super();
         this.type = FetchType.COLLECT_DATA;
@@ -55,9 +56,10 @@ export class CollectDataFetch extends AbstractDataFetch {
         this.selectedMeasure = selectedMeasure;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.useSubject = useSubject;
+
         if (selectedPatient) this.selectedPatient = selectedPatient;
         if (patientGroup) this.patientGroup = patientGroup;
-        if (useSubject) this.useSubject = useSubject;
 
     }
 

--- a/src/data/EvaluateMeasureFetch.tsx
+++ b/src/data/EvaluateMeasureFetch.tsx
@@ -1,5 +1,4 @@
 import { Constants } from '../constants/Constants';
-import { Measure } from '../models/Measure';
 import { Patient } from '../models/Patient';
 import { PatientGroup } from '../models/PatientGroup';
 import { GroupElement } from '../models/Scoring';
@@ -24,12 +23,13 @@ export class EvaluateMeasureFetch extends AbstractDataFetch {
     useSubject: boolean = false;
 
     constructor(selectedServer: Server | undefined,
-        selectedPatient: Patient | undefined,
         selectedMeasure: string,
         startDate: string,
         endDate: string,
+        useSubject: boolean,
+        selectedPatient?: Patient,
         patientGroup?: PatientGroup | undefined,
-        useSubject?: boolean) {
+    ) {
 
         super();
         this.type = FetchType.EVALUATE_MEASURE;
@@ -57,17 +57,19 @@ export class EvaluateMeasureFetch extends AbstractDataFetch {
                 }
             }
         }
-        if (selectedServer) this.selectedServer = selectedServer;
-        if (selectedPatient) this.selectedPatient = selectedPatient;
-        if (selectedMeasure) this.selectedMeasure = selectedMeasure;
-        if (startDate) this.startDate = startDate;
-        if (endDate) this.endDate = endDate;
+
+        this.selectedServer = selectedServer;
+        this.selectedMeasure = selectedMeasure;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.useSubject = useSubject;
+
         if (patientGroup) this.patientGroup = patientGroup;
-        if (useSubject) this.useSubject = useSubject;
+        if (selectedPatient) this.selectedPatient = selectedPatient;
 
     }
 
- 
+
 
     public getUrl(): string {
 

--- a/src/data/EvaluateMeasureFetch.tsx
+++ b/src/data/EvaluateMeasureFetch.tsx
@@ -21,7 +21,7 @@ export class EvaluateMeasureFetch extends AbstractDataFetch {
     startDate: string = '';
     endDate: string = '';
     patientGroup: PatientGroup | undefined;
-    bypassGroupCheck: boolean = false;
+    useSubject: boolean = false;
 
     constructor(selectedServer: Server | undefined,
         selectedPatient: Patient | undefined,
@@ -29,7 +29,7 @@ export class EvaluateMeasureFetch extends AbstractDataFetch {
         startDate: string,
         endDate: string,
         patientGroup?: PatientGroup | undefined,
-        bypassGroupCheck?: boolean) {
+        useSubject?: boolean) {
 
         super();
         this.type = FetchType.EVALUATE_MEASURE;
@@ -50,7 +50,7 @@ export class EvaluateMeasureFetch extends AbstractDataFetch {
             throw new Error(StringUtils.format(Constants.missingProperty, 'endDate'));
         }
 
-        if (!bypassGroupCheck) {
+        if (useSubject) {
             if (!selectedPatient || selectedPatient.id === '') {
                 if (!patientGroup || patientGroup.id === '') {
                     throw new Error(StringUtils.format(Constants.missingProperty, 'Patient or Group'));
@@ -63,22 +63,22 @@ export class EvaluateMeasureFetch extends AbstractDataFetch {
         if (startDate) this.startDate = startDate;
         if (endDate) this.endDate = endDate;
         if (patientGroup) this.patientGroup = patientGroup;
-        if (bypassGroupCheck) this.bypassGroupCheck = bypassGroupCheck;
+        if (useSubject) this.useSubject = useSubject;
 
     }
 
+ 
+
     public getUrl(): string {
-        // '{0}/Measure/{1}/$evaluate-measure?periodStart={2}&periodEnd={3}&reportType=subject-list';
 
         let subject = '';
-        if (this.selectedPatient?.id) {
-            subject = 'Patient/' + this.selectedPatient.id;
-        } else if (this.patientGroup) {
-            subject = 'Group/' + this.patientGroup.id;
-        }
-
-        if (this.bypassGroupCheck && !this.selectedPatient?.id) {
-            return StringUtils.format(Constants.evaluateMeasureWithSubjectFetchURL.replace('&subject={4}', ''),
+        if (this.useSubject) {
+            if (this.selectedPatient?.id) {
+                subject = 'Patient/' + this.selectedPatient.id;
+            } else if (this.patientGroup) {
+                subject = 'Group/' + this.patientGroup.id;
+            }
+            return StringUtils.format(Constants.evaluateMeasureWithSubjectFetchURL,
                 this.selectedServer?.baseUrl,
                 this.selectedMeasure,
                 this.startDate,
@@ -87,14 +87,14 @@ export class EvaluateMeasureFetch extends AbstractDataFetch {
             );
         }
 
-
-        return StringUtils.format(Constants.evaluateMeasureWithSubjectFetchURL,
+        //useSubject not true, return url without subject line
+        return StringUtils.format(Constants.evaluateMeasureWithSubjectFetchURL.replace('&subject={4}', ''),
             this.selectedServer?.baseUrl,
             this.selectedMeasure,
             this.startDate,
-            this.endDate,
-            subject
+            this.endDate
         );
+
     }
 
     protected processReturnedData(data: any) {

--- a/src/data/GroupFetch.tsx
+++ b/src/data/GroupFetch.tsx
@@ -43,6 +43,7 @@ export class GroupFetch extends AbstractDataFetch {
                     member: entry.resource.member
                 }
 
+                // console.log(measureName + ' has a Group file.')
                 groupMap.set(measureName, group)
             }
         }

--- a/src/tests/app/App.DataRepository.test.tsx
+++ b/src/tests/app/App.DataRepository.test.tsx
@@ -19,6 +19,8 @@ import jsonTestGroupData from '../resources/fetchmock-group.json';
 import jsonTestMeasureData from '../resources/fetchmock-measure.json';
 import jsonTestPatientsData from '../resources/fetchmock-patients.json';
 
+const useSubject = true;
+
 const thisTestFile = "Data Repository";
 
 const RESPONSE_ERROR_BAD_REQUEST = 'Bad Request';
@@ -176,20 +178,24 @@ test(thisTestFile + ': success scenario: Collect Data', async () => {
   });
   fetchMock.restore();
 
-  const patientDropdown: HTMLSelectElement = screen.getByTestId('data-repo-patient-dropdown');
+  //first select measure
+  const knowledgeRepoMeasureDropdown: HTMLSelectElement = screen.getByTestId('knowledge-repo-measure-dropdown');
+  userEvent.selectOptions(knowledgeRepoMeasureDropdown, mockMeasureList[0].name);
 
+  //now select patient
+  const patientDropdown: HTMLSelectElement = screen.getByTestId('data-repo-patient-dropdown');
   const expectedDisplayName: string = PatientFetch.buildUniquePatientIdentifier(mockPatientList[0]) + '';
   userEvent.selectOptions(patientDropdown, expectedDisplayName);
 
-  const knowledgeRepoMeasureDropdown: HTMLSelectElement = screen.getByTestId('knowledge-repo-measure-dropdown');
-  userEvent.selectOptions(knowledgeRepoMeasureDropdown, mockMeasureList[0].name);
 
   //mock returned data repo data
   const collectDataFetch = new CollectDataFetch(dataServers[0],
     mockMeasureList[0].name,
     startDate,
     endDate,
+    useSubject,
     mockPatientList[0]);
+
   const mockJsonCollectDataData = jsonTestCollectDataData;
   fetchMock.once(collectDataFetch.getUrl(),
     JSON.stringify(mockJsonCollectDataData)
@@ -200,6 +206,7 @@ test(thisTestFile + ': success scenario: Collect Data', async () => {
     const collectDataButton: HTMLButtonElement = screen.getByTestId('data-repo-collect-data-button');
     fireEvent.click(collectDataButton);
   });
+
   fetchMock.restore();
 
   expect(resultsTextField.value).toEqual(JSON.stringify(mockJsonCollectDataData, undefined, 2));
@@ -266,18 +273,21 @@ test(thisTestFile + ': fail scenario: data repository', async () => {
   });
   fetchMock.restore();
 
+  //first select measure
+  const knowledgeRepoMeasureDropdown: HTMLSelectElement = screen.getByTestId('knowledge-repo-measure-dropdown');
+  userEvent.selectOptions(knowledgeRepoMeasureDropdown, mockMeasureList[0].name);
+
+  //now select patient
   const patientDropdown: HTMLSelectElement = screen.getByTestId('data-repo-patient-dropdown');
   const expectedDisplayName: string = PatientFetch.buildUniquePatientIdentifier(mockPatientList[0]) + '';
   userEvent.selectOptions(patientDropdown, expectedDisplayName);
-
-  const knowledgeRepoMeasureDropdown: HTMLSelectElement = screen.getByTestId('knowledge-repo-measure-dropdown');
-  userEvent.selectOptions(knowledgeRepoMeasureDropdown, mockMeasureList[0].name);
 
   //mock returned data repo data
   const collectDataFetch = new CollectDataFetch(dataServers[0],
     mockMeasureList[0].name,
     startDate,
     endDate,
+    useSubject,
     mockPatientList[0]);
   fetchMock.once(collectDataFetch.getUrl(), 400);
 

--- a/src/tests/app/App.MeasureEvaluation.test.tsx
+++ b/src/tests/app/App.MeasureEvaluation.test.tsx
@@ -22,6 +22,8 @@ import jsonTestPatientsData from '../resources/fetchmock-patients.json';
 
 const thisTestFile = "Measure Evaluation";
 
+const useSubject = true;
+
 const mockPatientTotalCountJSON = `{
   "resourceType": "Bundle",
   "id": "604e7395-8850-4a15-a2f2-67a1d334b2d0",
@@ -175,10 +177,11 @@ test(thisTestFile + ' success scenario: evaluate data', async () => {
 
     //mock returned measure evaluation data
     const evaluateDataFetch = new EvaluateMeasureFetch(dataServers[0],
-      mockPatientList[0],
       mockMeasureList[0].name,
       startDate,
-      endDate);
+      endDate,
+      useSubject,
+      mockPatientList[0]);
     const mockJsonResultsData = jsonTestMeasureEvaluationData;
     fetchMock.once(evaluateDataFetch.getUrl(),
       JSON.stringify(mockJsonResultsData)
@@ -284,6 +287,7 @@ test(thisTestFile + ' success scenario: submit data', async () => {
       mockMeasureList[0].name,
       startDate,
       endDate,
+      useSubject,
       mockPatientList[0]);
     const mockJsonCollectDataData = jsonTestCollectDataData;
     fetchMock.once(collectDataFetch.getUrl(),
@@ -322,9 +326,9 @@ test(thisTestFile + ' success scenario: submit data', async () => {
     });
     fetchMock.restore();
     const resultsTextField: HTMLTextAreaElement = screen.getByTestId('results-text');
- 
+
     const swCon: boolean = resultsTextField.value.startsWith(Constants.dataSubmitted);
-    
+
     expect(swCon).toEqual(true);
   }
 });
@@ -532,10 +536,11 @@ test(thisTestFile + ' fail scenario: evaluate data without selecting Server', as
 
     //mock returned measure evaluation data
     const evaluateDataFetch = new EvaluateMeasureFetch(dataServers[0],
-      mockPatientList[0],
       mockMeasureList[0].name,
       startDate,
-      endDate);
+      endDate,
+      useSubject,
+      mockPatientList[0]);
     const mockJsonResultsData = jsonTestMeasureEvaluationData;
     fetchMock.once(evaluateDataFetch.getUrl(),
       JSON.stringify(mockJsonResultsData)

--- a/src/tests/app/App.ReceivingSystem.test.tsx
+++ b/src/tests/app/App.ReceivingSystem.test.tsx
@@ -178,13 +178,14 @@ test(thisTestFile + ' success scenario: submit', async () => {
     });
     fetchMock.restore();
 
-    const patientDropdown: HTMLSelectElement = screen.getByTestId('data-repo-patient-dropdown');
-
-    const expectedDisplayName: string = PatientFetch.buildUniquePatientIdentifier(mockPatientList[0]) + '';
-    userEvent.selectOptions(patientDropdown, expectedDisplayName);
-
+    //first select measure
     const knowledgeRepoMeasureDropdown: HTMLSelectElement = screen.getByTestId('knowledge-repo-measure-dropdown');
     userEvent.selectOptions(knowledgeRepoMeasureDropdown, mockMeasureList[0].name);
+
+    //now select patient
+    const patientDropdown: HTMLSelectElement = screen.getByTestId('data-repo-patient-dropdown');
+    const expectedDisplayName: string = PatientFetch.buildUniquePatientIdentifier(mockPatientList[0]) + '';
+    userEvent.selectOptions(patientDropdown, expectedDisplayName);
   }
 
 
@@ -199,10 +200,11 @@ test(thisTestFile + ' success scenario: submit', async () => {
 
     //mock returned measure evaluation data
     const evaluateDataFetch = new EvaluateMeasureFetch(dataServers[0],
-      mockPatientList[0],
       mockMeasureList[0].name,
       startDate,
-      endDate);
+      endDate,
+      true,
+      mockPatientList[0]);
     const mockJsonResultsData = jsonTestMeasureEvaluationData;
     fetchMock.once(evaluateDataFetch.getUrl(),
       JSON.stringify(mockJsonResultsData)
@@ -331,13 +333,14 @@ test(thisTestFile + ' fail scenario: submit', async () => {
     });
     fetchMock.restore();
 
-    const patientDropdown: HTMLSelectElement = screen.getByTestId('data-repo-patient-dropdown');
-
-    const expectedDisplayName: string = PatientFetch.buildUniquePatientIdentifier(mockPatientList[0]) + '';
-    userEvent.selectOptions(patientDropdown, expectedDisplayName);
-
+    //first select measure
     const knowledgeRepoMeasureDropdown: HTMLSelectElement = screen.getByTestId('knowledge-repo-measure-dropdown');
     userEvent.selectOptions(knowledgeRepoMeasureDropdown, mockMeasureList[0].name);
+
+    //now select patient
+    const patientDropdown: HTMLSelectElement = screen.getByTestId('data-repo-patient-dropdown');
+    const expectedDisplayName: string = PatientFetch.buildUniquePatientIdentifier(mockPatientList[0]) + '';
+    userEvent.selectOptions(patientDropdown, expectedDisplayName);
   }
 
 
@@ -352,10 +355,11 @@ test(thisTestFile + ' fail scenario: submit', async () => {
 
     //mock returned measure evaluation data
     const evaluateDataFetch = new EvaluateMeasureFetch(dataServers[0],
-      mockPatientList[0],
       mockMeasureList[0].name,
       startDate,
-      endDate);
+      endDate,
+      true,
+      mockPatientList[0]);
     const mockJsonResultsData = jsonTestMeasureEvaluationData;
     fetchMock.once(evaluateDataFetch.getUrl(),
       JSON.stringify(mockJsonResultsData)
@@ -488,13 +492,14 @@ test(thisTestFile + ' fail scenario: submit without server selection', async () 
     });
     fetchMock.restore();
 
-    const patientDropdown: HTMLSelectElement = screen.getByTestId('data-repo-patient-dropdown');
-
-    const expectedDisplayName: string = PatientFetch.buildUniquePatientIdentifier(mockPatientList[0]) + '';
-    userEvent.selectOptions(patientDropdown, expectedDisplayName);
-
+    //first select measure
     const knowledgeRepoMeasureDropdown: HTMLSelectElement = screen.getByTestId('knowledge-repo-measure-dropdown');
     userEvent.selectOptions(knowledgeRepoMeasureDropdown, mockMeasureList[0].name);
+
+    //now select patient
+    const patientDropdown: HTMLSelectElement = screen.getByTestId('data-repo-patient-dropdown');
+    const expectedDisplayName: string = PatientFetch.buildUniquePatientIdentifier(mockPatientList[0]) + '';
+    userEvent.selectOptions(patientDropdown, expectedDisplayName);
   }
 
 
@@ -509,10 +514,11 @@ test(thisTestFile + ' fail scenario: submit without server selection', async () 
 
     //mock returned measure evaluation data
     const evaluateDataFetch = new EvaluateMeasureFetch(dataServers[0],
-      mockPatientList[0],
       mockMeasureList[0].name,
       startDate,
-      endDate);
+      endDate,
+      true,
+      mockPatientList[0]);
     const mockJsonResultsData = jsonTestMeasureEvaluationData;
     fetchMock.once(evaluateDataFetch.getUrl(),
       JSON.stringify(mockJsonResultsData)

--- a/src/tests/app/App.TestComparator.test.tsx
+++ b/src/tests/app/App.TestComparator.test.tsx
@@ -1,0 +1,389 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
+import App from '../../App';
+import { Constants } from '../../constants/Constants';
+import { EvaluateMeasureFetch } from '../../data/EvaluateMeasureFetch';
+import { GroupFetch } from '../../data/GroupFetch';
+import { MeasureFetch } from '../../data/MeasureFetch';
+import { MeasureReportFetch } from '../../data/MeasureReportFetch';
+import { PatientFetch } from '../../data/PatientFetch';
+import { Measure } from '../../models/Measure';
+import { Patient } from '../../models/Patient';
+import { Server } from '../../models/Server';
+import { HashParamUtils } from '../../utils/HashParamUtils';
+import { ServerUtils } from '../../utils/ServerUtils';
+import jsonTestMeasureData from '../resources/fetchmock-measure.json';
+import jsonTestEvalMeasure from '../resources/fetchmock-test-compare-evaluate-measure.json';
+import jsonTestGroupData from '../resources/fetchmock-test-compare-group.json';
+import jsonTestMeasureReport from '../resources/fetchmock-test-compare-measure-report.json';
+import jsonTestPatientsData from '../resources/fetchmock-test-compare-patients.json';
+
+const thisTestFile = "Test Comparator";
+
+const mockPatientTotalCountJSON = `{
+  "resourceType": "Bundle",
+  "id": "89b1e43b-626b-4fa7-af3f-2b30d5858123",
+  "meta": {
+    "lastUpdated": "2024-09-16T14:51:41.282+00:00",
+    "tag": [ {
+      "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
+      "code": "SUBSETTED",
+      "display": "Resource encoded in summary mode"
+    } ]
+  },
+  "type": "searchset",
+  "total": 2355
+}`;
+
+//mock getServerList and createServer entirely. API.graphQL calls are mocked in ServerUtils.test.tsx
+beforeEach(() => {
+  //clean up any missed mocks
+  jest.restoreAllMocks();
+  fetchMock.restore();
+
+  //override getServerList to return test data
+  jest.spyOn(ServerUtils, 'getServerList').mockImplementation(async () => {
+    return Constants.serverTestData;
+  });
+
+  //clear out old accessCode, generateStateCode, and stateCode values
+  HashParamUtils.clearCachedValues();
+
+  //reset the selected knowledge repo stored in sessionStorage
+  sessionStorage.setItem('selectedKnowledgeRepo', JSON.stringify(''));
+
+  //override any calls directly to 127.0.0.1:8080, simply return result.ok set to true;
+  fetchMock.mock('begin:http://127.0.0.1:8080', true);
+
+});
+
+//RENDERING: 
+test(thisTestFile + 'renders properly', async () => {
+  await act(async () => {
+    render(<App />);
+  });
+
+  expect(screen.getByTestId('test-compare-show-section-button')).toBeInTheDocument();
+  const showButton: HTMLButtonElement = screen.getByTestId('test-compare-show-section-button');
+  fireEvent.click(showButton);
+
+  expect(screen.getByTestId('test-compare-generate-summary-button')).toBeInTheDocument();
+
+  //verify the checklist:
+  expect(screen.getByTestId('test-compare-checklist-measure')).toBeInTheDocument();
+  expect(screen.getByTestId('test-compare-checklist-data-repo-server')).toBeInTheDocument();
+  expect(screen.getByTestId('test-compare-checklist-patient-group')).toBeInTheDocument();
+  expect(screen.getByTestId('test-compare-checklist-measure-eval-server')).toBeInTheDocument();
+
+  const hideButton: HTMLButtonElement = screen.getByTestId('test-compare-hide-section-button');
+  fireEvent.click(hideButton);
+});
+
+
+test(thisTestFile + ' success scenario: generate a valid test comparison summary', async () => {
+  const INITIAL_POPULATION = 'initial-population';
+  const DENOMINATOR = 'denominator';
+  const DENOMINATOR_EXCLUSION = 'denominator-exclusion';
+  const NUMERATOR = 'numerator';
+  const PATIENT_NAME = '11yoDepressionScreening IPFail';
+  const PATIENT_ID = '80c4155e-5671-454a-a4ec-5d774fcef8d2';
+  const DISCREPANCY = 'Discrepancy';
+
+  const dataServers: Server[] = Constants.serverTestData;
+  const mockMeasureList: Measure[] = await buildMeasureData(dataServers[0].baseUrl);
+  const mockPatientList: Patient[] = await buildPatientData(dataServers[0].baseUrl);
+
+  await act(async () => {
+    render(<App />);
+  });
+
+
+  //Show test Comparator section to track check list:
+  expect(screen.getByTestId('test-compare-show-section-button')).toBeInTheDocument();
+  fireEvent.click(screen.getByTestId('test-compare-show-section-button'));
+  await waitFor(() => expect(screen.getByTestId('test-compare-generate-summary-button')).toBeInTheDocument());
+
+  //verify the checklist:
+  expect(screen.getByTestId('test-compare-checklist-measure')).toBeInTheDocument();
+  expect(screen.getByTestId('test-compare-checklist-data-repo-server')).toBeInTheDocument();
+  expect(screen.getByTestId('test-compare-checklist-patient-group')).toBeInTheDocument();
+  expect(screen.getByTestId('test-compare-checklist-measure-eval-server')).toBeInTheDocument();
+
+  expect(screen.getByTestId('test-compare-checklist-measure').innerHTML).toEqual('☐ Measure');
+  expect(screen.getByTestId('test-compare-checklist-data-repo-server').innerHTML).toEqual('☐ Data Repository Server');
+  expect(screen.getByTestId('test-compare-checklist-patient-group').innerHTML).toEqual('☐ Patient Group');
+  expect(screen.getByTestId('test-compare-checklist-measure-eval-server').innerHTML).toEqual('☐ Measure Evaluation Server');
+
+
+  const startDateControl: HTMLInputElement = screen.getByTestId('start-date-control');
+  const periodStart = startDateControl.value;
+
+  const endDateControl: HTMLInputElement = screen.getByTestId('end-date-control');
+  const periodEnd = endDateControl.value;
+
+
+  //Select a measure via knowledge repository:
+  {
+    const serverDropdown: HTMLSelectElement = screen.getByTestId('knowledge-repo-server-dropdown');
+    const measureDropdown: HTMLSelectElement = screen.getByTestId('knowledge-repo-measure-dropdown');
+
+    //mock measure list server selection will return 
+    await act(async () => {
+      const measureFetch = new MeasureFetch(dataServers[0].baseUrl);
+      const mockJsonMeasureData = jsonTestMeasureData;
+      fetchMock.once(measureFetch.getUrl(), JSON.stringify(mockJsonMeasureData), { method: 'GET' });
+      userEvent.selectOptions(serverDropdown, dataServers[0].baseUrl);
+    });
+    fetchMock.restore();
+
+    //select a Measure
+    await act(async () => {
+      userEvent.selectOptions(measureDropdown, mockMeasureList[0].name);
+    });
+  }
+
+  //Select a Patient via Data Repo section:
+  {
+    expect(screen.getByTestId('data-repo-show-section-button')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('data-repo-show-section-button'));
+
+    await waitFor(() => expect(screen.getByTestId('data-repo-collect-data-button')).toBeInTheDocument());
+
+    const knowledgeRepoServerDropdown: HTMLSelectElement = screen.getByTestId('knowledge-repo-server-dropdown');
+    const serverDropdown: HTMLSelectElement = screen.getByTestId('data-repo-server-dropdown');
+
+    //select server, mock list should return:
+    await act(async () => {
+      fetchMock.mock(dataServers[0].baseUrl + 'Patient?_summary=count', mockPatientTotalCountJSON);
+
+      const patientFetch = await PatientFetch.createInstance(dataServers[0].baseUrl);
+      const mockJsonPatientData = jsonTestPatientsData;
+      fetchMock.once(patientFetch.getUrl(),
+        JSON.stringify(mockJsonPatientData)
+        , { method: 'GET' });
+
+      const groupFetch = new GroupFetch(dataServers[0].baseUrl);
+      const mockJsonGroupData = jsonTestGroupData;
+      fetchMock.once(groupFetch.getUrl(),
+        JSON.stringify(mockJsonGroupData)
+        , { method: 'GET' });
+
+      userEvent.selectOptions(serverDropdown, dataServers[0].baseUrl);
+    });
+    fetchMock.restore();
+
+    //mock measure list server selection will return 
+    const measureFetch = new MeasureFetch(dataServers[0].baseUrl);
+    const mockJsonMeasureData = jsonTestMeasureData;
+    fetchMock.once(measureFetch.getUrl(),
+      JSON.stringify(mockJsonMeasureData)
+      , { method: 'GET' });
+    await act(async () => {
+      //select server, mock list should return:
+      userEvent.selectOptions(knowledgeRepoServerDropdown, dataServers[0].baseUrl);
+    });
+    fetchMock.restore();
+
+    const patientDropdown: HTMLSelectElement = screen.getByTestId('data-repo-patient-dropdown');
+
+    const expectedDisplayName: string = PatientFetch.buildUniquePatientIdentifier(mockPatientList[0]) + '';
+    userEvent.selectOptions(patientDropdown, expectedDisplayName);
+  }
+
+
+  //Evaluate Measure via Measure Evaluation section:
+  {
+    expect(screen.getByTestId('mea-eva-show-section-button')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('mea-eva-show-section-button'));
+    await waitFor(() => expect(screen.getByTestId('mea-eva-evaluate-button')).toBeInTheDocument());
+
+    const serverDropdown: HTMLSelectElement = screen.getByTestId('mea-eva-server-dropdown');
+    userEvent.selectOptions(serverDropdown, dataServers[0].baseUrl);
+
+  }
+  //Test Comparator:
+  {
+    //verify selections on screen completed the checklist:
+    expect(screen.getByTestId('test-compare-checklist-measure').innerHTML).toEqual('☑ Measure<span> <a target=\"_blank\" rel=\"noreferrer\" href=\"http://localhost:8080/1/Measure/AlaraCTClinicalFHIR\">(AlaraCTClinicalFHIR)</a></span>');
+    expect(screen.getByTestId('test-compare-checklist-data-repo-server').innerHTML).toEqual('☑ Data Repository Server<span> <a target=\"_blank\" rel=\"noreferrer\" href=\"http://localhost:8080/1/\">(http://localhost:8080/1/)</a></span>');
+    expect(screen.getByTestId('test-compare-checklist-patient-group').innerHTML).toEqual('☑ Patient Group<span> <a target=\"_blank\" rel=\"noreferrer\" href=\"http://localhost:8080/1/Group/17595\">(Group/17595)</a></span>');
+    expect(screen.getByTestId('test-compare-checklist-measure-eval-server').innerHTML).toEqual('☑ Measure Evaluation Server<span> <a target=\"_blank\" rel=\"noreferrer\" href=\"http://localhost:8080/1/\">(http://localhost:8080/1/)</a></span>');
+
+    //Evaluate Measure mock
+    const evaluateMeasuresFetch = new EvaluateMeasureFetch(dataServers[0],
+      mockMeasureList[0].name, periodStart, periodEnd, true, mockPatientList[0]);
+    const mockJsonEvaluateMeasureData = jsonTestEvalMeasure;
+    fetchMock.once(evaluateMeasuresFetch.getUrl(),
+      JSON.stringify(mockJsonEvaluateMeasureData)
+      , { method: 'GET' });
+
+    //Mock MeasureReport:
+    const mockJsonMeasureReportData = jsonTestMeasureReport;
+    const measureReportFetch = new MeasureReportFetch(dataServers[0],
+      mockPatientList[0], mockMeasureList[0].name, periodStart, periodEnd);
+    fetchMock.once(measureReportFetch.getUrl(),
+      JSON.stringify(mockJsonMeasureReportData)
+      , { method: 'GET' });
+
+    await act(async () => {
+      const generateTestSummaryButton: HTMLButtonElement = screen.getByTestId('test-compare-generate-summary-button');
+      await fireEvent.click(generateTestSummaryButton);
+    });
+
+    fetchMock.restore();
+
+    expect(screen.getByTestId('test-comp-pat-eval-count')).toBeInTheDocument();
+    const testCompPatEvalCountDiv: HTMLDivElement = screen.getByTestId('test-comp-pat-eval-count');
+    expect(testCompPatEvalCountDiv.innerHTML).toEqual('1');
+
+    expect(screen.getByTestId('test-comp-disc-found-count')).toBeInTheDocument();
+    const testCompDiscFoundCountDiv: HTMLDivElement = screen.getByTestId('test-comp-disc-found-count');
+    expect(testCompDiscFoundCountDiv.innerHTML).toEqual('1');
+
+    expect(screen.getByTestId('test-comp-match-count')).toBeInTheDocument();
+    const testCompMatchCountDiv: HTMLDivElement = screen.getByTestId('test-comp-match-count');
+    expect(testCompMatchCountDiv.innerHTML).toEqual('0');
+
+    expect(screen.getByTestId('test-comp-start-date')).toBeInTheDocument();
+    const testCompStartDateDiv: HTMLDivElement = screen.getByTestId('test-comp-start-date');
+    expect(testCompStartDateDiv.innerHTML).toEqual(periodStart);
+
+    expect(screen.getByTestId('test-comp-end-date')).toBeInTheDocument();
+    const testCompEndDateDiv: HTMLDivElement = screen.getByTestId('test-comp-end-date');
+    expect(testCompEndDateDiv.innerHTML).toEqual(periodEnd);
+
+    expect(screen.getByTestId('test-comp-now-date')).toBeInTheDocument();
+    const testCompNowDateDiv: HTMLDivElement = screen.getByTestId('test-comp-now-date');
+    expect(testCompNowDateDiv.innerHTML).toEqual(getNow());
+
+    expect(screen.getByTestId('test-comp-patient-display' + convertToID(mockPatientList[0]?.id))).toBeInTheDocument();
+    const testCompPatientDisplayDiv: HTMLDivElement = screen.getByTestId('test-comp-patient-display' + convertToID(mockPatientList[0]?.id));
+    expect(testCompPatientDisplayDiv.innerHTML).toEqual(PATIENT_NAME);
+
+    expect(screen.getByTestId('test-comp-patient-id' + convertToID(mockPatientList[0]?.id))).toBeInTheDocument();
+    const testCompPatientIdDiv: HTMLDivElement = screen.getByTestId('test-comp-patient-id' + convertToID(mockPatientList[0]?.id));
+    expect(testCompPatientIdDiv.innerHTML).toEqual('ID: ' + PATIENT_ID);
+
+    expect(screen.getByTestId('test-comp-result-' + convertToID(mockPatientList[0]?.id))).toBeInTheDocument();
+    const testCompResultDiv: HTMLDivElement = screen.getByTestId('test-comp-result-' + convertToID(mockPatientList[0]?.id));
+    expect(testCompResultDiv.innerHTML).toEqual(DISCREPANCY);
+
+
+    //test id's for the array based on id+index of entry:
+    //This Evaluation:
+    {
+      expect(screen.getByTestId('test-comp-this-eval-group-code-0')).toBeInTheDocument();
+      const testCompThisEvalGroupCodeDiv0: HTMLDivElement = screen.getByTestId('test-comp-this-eval-group-code-0');
+      expect(testCompThisEvalGroupCodeDiv0.innerHTML).toEqual(INITIAL_POPULATION);
+
+      expect(screen.getByTestId('test-comp-this-eval-group-count-0')).toBeInTheDocument();
+      const testCompThisEvalGroupCountDiv0: HTMLDivElement = screen.getByTestId('test-comp-this-eval-group-count-0');
+      expect(testCompThisEvalGroupCountDiv0.innerHTML).toEqual('1');
+
+
+      expect(screen.getByTestId('test-comp-this-eval-group-code-0')).toBeInTheDocument();
+      const testCompThisEvalGroupCodeDiv1: HTMLDivElement = screen.getByTestId('test-comp-this-eval-group-code-1');
+      expect(testCompThisEvalGroupCodeDiv1.innerHTML).toEqual(DENOMINATOR);
+
+      expect(screen.getByTestId('test-comp-this-eval-group-count-0')).toBeInTheDocument();
+      const testCompThisEvalGroupCountDiv1: HTMLDivElement = screen.getByTestId('test-comp-this-eval-group-count-1');
+      expect(testCompThisEvalGroupCountDiv1.innerHTML).toEqual('0');
+
+
+      expect(screen.getByTestId('test-comp-this-eval-group-code-0')).toBeInTheDocument();
+      const testCompThisEvalGroupCodeDiv2: HTMLDivElement = screen.getByTestId('test-comp-this-eval-group-code-2');
+      expect(testCompThisEvalGroupCodeDiv2.innerHTML).toEqual(DENOMINATOR_EXCLUSION);
+
+      expect(screen.getByTestId('test-comp-this-eval-group-count-0')).toBeInTheDocument();
+      const testCompThisEvalGroupCountDiv2: HTMLDivElement = screen.getByTestId('test-comp-this-eval-group-count-2');
+      expect(testCompThisEvalGroupCountDiv2.innerHTML).toEqual('1');
+
+
+      expect(screen.getByTestId('test-comp-this-eval-group-code-0')).toBeInTheDocument();
+      const testCompThisEvalGroupCodeDiv3: HTMLDivElement = screen.getByTestId('test-comp-this-eval-group-code-3');
+      expect(testCompThisEvalGroupCodeDiv3.innerHTML).toEqual(NUMERATOR);
+
+      expect(screen.getByTestId('test-comp-this-eval-group-count-0')).toBeInTheDocument();
+      const testCompThisEvalGroupCountDiv3: HTMLDivElement = screen.getByTestId('test-comp-this-eval-group-count-3');
+      expect(testCompThisEvalGroupCountDiv3.innerHTML).toEqual('0');
+
+    }
+
+    // //Previous Measure Report
+    {
+      expect(screen.getByTestId('test-comp-prev-eval-group-code-0')).toBeInTheDocument();
+      const testCompPrevEvalGroupCodeDiv0: HTMLDivElement = screen.getByTestId('test-comp-prev-eval-group-code-0');
+      expect(testCompPrevEvalGroupCodeDiv0.innerHTML).toEqual(INITIAL_POPULATION);
+
+      expect(screen.getByTestId('test-comp-prev-eval-group-count-0')).toBeInTheDocument();
+      const testCompPrevEvalGroupCountDiv0: HTMLDivElement = screen.getByTestId('test-comp-prev-eval-group-count-0');
+      expect(testCompPrevEvalGroupCountDiv0.innerHTML).toEqual('1');
+
+
+      expect(screen.getByTestId('test-comp-prev-eval-group-code-0')).toBeInTheDocument();
+      const testCompPrevEvalGroupCodeDiv1: HTMLDivElement = screen.getByTestId('test-comp-prev-eval-group-code-1');
+      expect(testCompPrevEvalGroupCodeDiv1.innerHTML).toEqual(DENOMINATOR);
+
+      expect(screen.getByTestId('test-comp-prev-eval-group-count-0')).toBeInTheDocument();
+      const testCompPrevEvalGroupCountDiv1: HTMLDivElement = screen.getByTestId('test-comp-prev-eval-group-count-1');
+      expect(testCompPrevEvalGroupCountDiv1.innerHTML).toEqual('1');
+
+
+      expect(screen.getByTestId('test-comp-prev-eval-group-code-0')).toBeInTheDocument();
+      const testCompPrevEvalGroupCodeDiv2: HTMLDivElement = screen.getByTestId('test-comp-prev-eval-group-code-2');
+      expect(testCompPrevEvalGroupCodeDiv2.innerHTML).toEqual(DENOMINATOR_EXCLUSION);
+
+      expect(screen.getByTestId('test-comp-prev-eval-group-count-0')).toBeInTheDocument();
+      const testCompPrevEvalGroupCountDiv2: HTMLDivElement = screen.getByTestId('test-comp-prev-eval-group-count-2');
+      expect(testCompPrevEvalGroupCountDiv2.innerHTML).toEqual('0');
+
+
+      expect(screen.getByTestId('test-comp-prev-eval-group-code-0')).toBeInTheDocument();
+      const testCompPrevEvalGroupCodeDiv3: HTMLDivElement = screen.getByTestId('test-comp-prev-eval-group-code-3');
+      expect(testCompPrevEvalGroupCodeDiv3.innerHTML).toEqual(NUMERATOR);
+
+      expect(screen.getByTestId('test-comp-prev-eval-group-count-0')).toBeInTheDocument();
+      const testCompPrevEvalGroupCountDiv3: HTMLDivElement = screen.getByTestId('test-comp-prev-eval-group-count-3');
+      expect(testCompPrevEvalGroupCountDiv3.innerHTML).toEqual('1');
+
+    }
+
+  }
+});
+
+//mock measure and patient data
+async function buildMeasureData(url: string): Promise<Measure[]> {
+  const measureFetch = new MeasureFetch(url);
+  const mockJsonMeasureData = jsonTestMeasureData;
+  fetchMock.once(measureFetch.getUrl(),
+    JSON.stringify(mockJsonMeasureData)
+    , { method: 'GET' });
+  let measureList: Measure[] = await measureFetch.fetchData('');
+  fetchMock.restore();
+  return measureList;
+}
+
+async function buildPatientData(url: string): Promise<Patient[]> {
+  fetchMock.mock(url + 'Patient?_summary=count', mockPatientTotalCountJSON);
+
+  const patientFetch = await PatientFetch.createInstance(url);
+  const mockJsonPatientData = jsonTestPatientsData;
+  fetchMock.once(patientFetch.getUrl(),
+    JSON.stringify(mockJsonPatientData)
+    , { method: 'GET' });
+  let patientList: Patient[] = await patientFetch.fetchData('');
+  fetchMock.restore();
+  return patientList;
+}
+
+const convertToID = (str: any | undefined): string => {
+  let strIn: string = '' + str;
+  return (strIn.replace(' ', ''));
+}
+
+const getNow = () => {
+  const today = new Date();
+  const formattedDate = today.toISOString().split('T')[0];
+  return formattedDate;
+}

--- a/src/tests/components/DataRepository.test.tsx
+++ b/src/tests/components/DataRepository.test.tsx
@@ -21,6 +21,7 @@ test('expect functions to be called when selecting items in dropdown', async () 
 
     const fetchPatients = jest.fn();
     const setSelectedPatient = jest.fn();
+    const setSelectedPatientGroup = jest.fn();
 
     render(<DataRepository
         showDataRepo={showDataRepo}
@@ -34,6 +35,7 @@ test('expect functions to be called when selecting items in dropdown', async () 
         collectData={jest.fn()}
         loading={loadingFlag}
         setModalShow={jest.fn()}
+        setSelectedPatientGroup={setSelectedPatientGroup}
     />);
 
     //select first server
@@ -59,6 +61,7 @@ test('expect spinner to show when loading is true', async () => {
 
     const fetchPatients = jest.fn();
     const setSelectedPatient = jest.fn();
+    const setSelectedPatientGroup = jest.fn();
 
     render(<DataRepository
         showDataRepo={showDataRepo}
@@ -72,6 +75,7 @@ test('expect spinner to show when loading is true', async () => {
         collectData={jest.fn()}
         loading={loadingFlag}
         setModalShow={jest.fn()}
+        setSelectedPatientGroup={setSelectedPatientGroup}
     />);
 
     const evaluateButtonWithSpinner: HTMLButtonElement = screen.getByTestId('data-repo-collect-data-button-spinner');
@@ -86,10 +90,10 @@ test('hide section', async () => {
     const showDataRepo: boolean = false;
 
     const setShowDataRepo = jest.fn();
-    const setSelectedDataRepo = jest.fn();
     const fetchPatients = jest.fn();
     const setSelectedPatient = jest.fn();
     const collectData = jest.fn();
+    const setSelectedPatientGroup = jest.fn();
 
 
     render(<DataRepository
@@ -104,6 +108,7 @@ test('hide section', async () => {
         collectData={collectData}
         loading={loadingFlag}
         setModalShow={jest.fn()}
+        setSelectedPatientGroup={setSelectedPatientGroup}
     />);
 
     const hideShowButton: HTMLButtonElement = screen.getByTestId('data-repo-show-section-button');
@@ -119,10 +124,10 @@ test('show section', async () => {
     const showDataRepo: boolean = true;
 
     const setShowDataRepo = jest.fn();
-    const setSelectedDataRepo = jest.fn();
     const fetchPatients = jest.fn();
     const setSelectedPatient = jest.fn();
     const collectData = jest.fn();
+    const setSelectedPatientGroup = jest.fn();
 
     render(<DataRepository
         showDataRepo={showDataRepo}
@@ -136,6 +141,7 @@ test('show section', async () => {
         collectData={collectData}
         loading={loadingFlag}
         setModalShow={jest.fn()}
+        setSelectedPatientGroup={setSelectedPatientGroup}
     />);
 
     const evaluateButton: HTMLButtonElement = screen.getByTestId('data-repo-hide-section-button');

--- a/src/tests/components/MeasureEvaluation.test.tsx
+++ b/src/tests/components/MeasureEvaluation.test.tsx
@@ -36,8 +36,10 @@ test('MeasureEvaluation expect functions to be called properly', async () => {
         evaluateMeasure={evaluateMeasure}
         loading={loadingFlag}
         setModalShow={jest.fn()}
-
-        populationScoring={populationScoring} showPopulations={showPopulations} measureScoringType={measureScoringType} 
+        populationScoring={populationScoring}
+        showPopulations={showPopulations}
+        measureScoringType={measureScoringType}
+        selectedDataRepo={servers[0]}
     />);
 
     const serverDropdown: HTMLSelectElement = screen.getByTestId('mea-eva-server-dropdown');
@@ -79,8 +81,10 @@ test('MeasureEvaluation expect spinner buttons to show with loading set to true'
         evaluateMeasure={evaluateMeasure}
         loading={loadingFlag}
         setModalShow={jest.fn()}
-
-        populationScoring={populationScoring} showPopulations={showPopulations} measureScoringType={measureScoringType} 
+        populationScoring={populationScoring}
+        showPopulations={showPopulations}
+        measureScoringType={measureScoringType}
+        selectedDataRepo={servers[0]}
     />);
 
     const submitDataButtonSpinner: HTMLButtonElement = screen.getByTestId('mea-eva-submit-button-spinner');
@@ -115,8 +119,10 @@ test('MeasureEvaluation hide/show functionality', async () => {
         evaluateMeasure={evaluateMeasure}
         loading={loadingFlag}
         setModalShow={jest.fn()}
-
-        populationScoring={populationScoring} showPopulations={showPopulations} measureScoringType={measureScoringType} 
+        populationScoring={populationScoring}
+        showPopulations={showPopulations}
+        measureScoringType={measureScoringType}
+        selectedDataRepo={servers[0]}
     />);
 
     const showHideButton: HTMLButtonElement = screen.getByTestId('mea-eva-hide-section-button');
@@ -135,7 +141,7 @@ test('MeasureEvaluation hide/show functionality 2', async () => {
     const setSelectedMeasureEvaluation = jest.fn();
     const submitData = jest.fn();
     const evaluateMeasure = jest.fn();
-    
+
     const showPopulations: boolean = false;
     const populationScoring: PopulationScoring[] = [];
     const measureScoringType: string = '';
@@ -150,8 +156,8 @@ test('MeasureEvaluation hide/show functionality 2', async () => {
         evaluateMeasure={evaluateMeasure}
         loading={loadingFlag}
         setModalShow={jest.fn()}
-
-        populationScoring={populationScoring} showPopulations={showPopulations} measureScoringType={measureScoringType} 
+        populationScoring={populationScoring} showPopulations={showPopulations} measureScoringType={measureScoringType}
+        selectedDataRepo={servers[0]}
     />);
 
     const showHideButton: HTMLButtonElement = screen.getByTestId('mea-eva-show-section-button');

--- a/src/tests/components/TestComparator.test.tsx
+++ b/src/tests/components/TestComparator.test.tsx
@@ -100,8 +100,8 @@ test(thisTestFile + ': renders properly', async () => {
         }
 
         //Evaluate Measure mock
-        const evaluateMeasuresFetch = new EvaluateMeasureFetch(dataServer, patientList[patientIdx],
-            MEASURE_NAME, periodStart, periodEnd);
+        const evaluateMeasuresFetch = new EvaluateMeasureFetch(dataServer,
+            MEASURE_NAME, periodStart, periodEnd, true, patientList[patientIdx]);
         const mockJsonEvaluateMeasureData = jsonTestEvalMeasure;
         fetchMock.once(evaluateMeasuresFetch.getUrl(),
             JSON.stringify(mockJsonEvaluateMeasureData)

--- a/src/tests/components/TestComparator.test.tsx
+++ b/src/tests/components/TestComparator.test.tsx
@@ -1,22 +1,19 @@
 import { act, render, screen } from '@testing-library/react';
-import TestingComparator from '../../components/TestingComparator';
-import { Patient } from '../../models/Patient';
-import { MeasureComparisonManager } from '../../utils/MeasureComparisonManager';
-
-import jsonTestEvalMeasure from '../resources/fetchmock-test-compare-evaluate-measure.json';
-import jsonTestMeasureReport from '../resources/fetchmock-test-compare-measure-report.json';
-import jsonTestPatientsData from '../resources/fetchmock-test-compare-patients.json';
-
-import jsonTestMeasureData from '../resources/fetchmock-measure.json';
-
 import fetchMock from 'fetch-mock';
+import TestingComparator from '../../components/TestingComparator';
 import { Constants } from '../../constants/Constants';
 import { EvaluateMeasureFetch } from '../../data/EvaluateMeasureFetch';
 import { MeasureFetch } from '../../data/MeasureFetch';
 import { MeasureReportFetch } from '../../data/MeasureReportFetch';
 import { PatientFetch } from '../../data/PatientFetch';
 import { Measure } from '../../models/Measure';
+import { Patient } from '../../models/Patient';
 import { Server } from '../../models/Server';
+import { MeasureComparisonManager } from '../../utils/MeasureComparisonManager';
+import jsonTestMeasureData from '../resources/fetchmock-measure.json';
+import jsonTestEvalMeasure from '../resources/fetchmock-test-compare-evaluate-measure.json';
+import jsonTestMeasureReport from '../resources/fetchmock-test-compare-measure-report.json';
+import jsonTestPatientsData from '../resources/fetchmock-test-compare-patients.json';
 
 const thisTestFile = "Test Comparator";
 
@@ -61,8 +58,6 @@ test(thisTestFile + ': renders properly', async () => {
     let patientList: Array<Patient | undefined> = [];
 
     await act(async () => {
-
-
         //Patient total count mock (used in url formation for Patient fetch)
         fetchMock.mock(baseUrl + 'Patient?_summary=count', mockPatientTotalCountJSON);
         const patientFetch = await PatientFetch.createInstance(baseUrl);
@@ -90,7 +85,6 @@ test(thisTestFile + ': renders properly', async () => {
                 break;
             }
         }
-
 
         for (const patient of patientList) {
             if (patient?.id === PATIENT_ID) {

--- a/src/tests/components/TestComparator.test.tsx
+++ b/src/tests/components/TestComparator.test.tsx
@@ -135,7 +135,10 @@ test(thisTestFile + ': renders properly', async () => {
 
     render(<TestingComparator showTestCompare={true} setShowTestCompare={setShowTestCompare}
         items={testComparatorMap} compareTestResults={compareTestResults} loading={loadingFlag}
-        startDate={periodStart} endDate={periodEnd} />);
+        startDate={periodStart} endDate={periodEnd}  
+        selectedDataRepoServer={dataServer} selectedPatientGroup={undefined}
+        selectedMeasureEvaluationServer={dataServer} selectedMeasure={MEASURE_NAME}
+        selectedKnowledgeRepositoryServer={dataServer} />);
 
     // const groupID1 = '2D0D08DB-219D-4C41-AB53-DE21F006D602';
 

--- a/src/tests/components/TestComparator.test.tsx
+++ b/src/tests/components/TestComparator.test.tsx
@@ -135,10 +135,10 @@ test(thisTestFile + ': renders properly', async () => {
 
     render(<TestingComparator showTestCompare={true} setShowTestCompare={setShowTestCompare}
         items={testComparatorMap} compareTestResults={compareTestResults} loading={loadingFlag}
-        startDate={periodStart} endDate={periodEnd}  
+        startDate={periodStart} endDate={periodEnd}
         selectedDataRepoServer={dataServer} selectedPatientGroup={undefined}
         selectedMeasureEvaluationServer={dataServer} selectedMeasure={MEASURE_NAME}
-        selectedKnowledgeRepositoryServer={dataServer} />);
+        selectedKnowledgeRepositoryServer={dataServer} selectedPatient={patientList[patientIdx]} />);
 
     // const groupID1 = '2D0D08DB-219D-4C41-AB53-DE21F006D602';
 

--- a/src/tests/data/CollectDataFetch.test.tsx
+++ b/src/tests/data/CollectDataFetch.test.tsx
@@ -6,7 +6,7 @@ import { ServerUtils } from '../../utils/ServerUtils';
 import { StringUtils } from '../../utils/StringUtils';
 import jsonTestCollectDataData from '../resources/fetchmock-data-repo.json';
 
-const selectedPatient = {display: 'John Doe', id: 'selectedPatient'};
+const selectedPatient = { display: 'John Doe', id: 'selectedPatient' };
 
 beforeEach(() => {
     jest.spyOn(ServerUtils, 'getServerList').mockImplementation(async () => {
@@ -21,6 +21,7 @@ test('required properties check', async () => {
             'selectedMeasure',
             'startDate',
             'endDate',
+            true,
             selectedPatient);
     } catch (error: any) {
         expect(error.message).toEqual(StringUtils.format(Constants.missingProperty, 'selectedDataRepo'))
@@ -31,6 +32,7 @@ test('required properties check', async () => {
             '',
             'startDate',
             'endDate',
+            true,
             selectedPatient);
     } catch (error: any) {
         expect(error.message).toEqual(StringUtils.format(Constants.missingProperty, 'selectedMeasure'))
@@ -41,6 +43,7 @@ test('required properties check', async () => {
             'selectedMeasure',
             '',
             'endDate',
+            true,
             selectedPatient);
     } catch (error: any) {
         expect(error.message).toEqual(StringUtils.format(Constants.missingProperty, 'startDate'))
@@ -51,6 +54,7 @@ test('required properties check', async () => {
             'selectedMeasure',
             'startDate',
             '',
+            true,
             selectedPatient);
     } catch (error: any) {
         expect(error.message).toEqual(StringUtils.format(Constants.missingProperty, 'endDate'))
@@ -65,6 +69,7 @@ test('get CollectData mock', async () => {
         'selectedMeasure',
         'startDate',
         'endDate',
+        true,
         selectedPatient);
     const mockJsonCollectDataData = jsonTestCollectDataData;
     fetchMock.once(collectDataFetch.getUrl(),
@@ -79,13 +84,14 @@ test('get CollectData mock', async () => {
 
 test('get CollectData mock error', async () => {
     const dataServer: Server = Constants.serverTestData[0];
-    
+
     const errorMsg = 'this is a test'
     let errorCatch = '';
     const collectDataFetch = new CollectDataFetch(dataServer,
         'selectedMeasure',
         'startDate',
         'endDate',
+        true,
         selectedPatient);
     fetchMock.once(collectDataFetch.getUrl(), { throws: new Error(errorMsg) });
 
@@ -95,7 +101,7 @@ test('get CollectData mock error', async () => {
         errorCatch = error.message;
     }
 
-    expect(errorCatch).toEqual('Using http://localhost:8080/1/Measure/selectedMeasure/$collect-data?periodStart=startDate&periodEnd=endDate&subject=selectedPatient to retrieve Collect Data caused: Error: this is a test');
+    expect(errorCatch).toEqual('Using http://localhost:8080/1/Measure/selectedMeasure/$collect-data?periodStart=startDate&periodEnd=endDate&subject=Patient/selectedPatient&reportType=subject-list to retrieve Collect Data caused: Error: this is a test');
 
     fetchMock.restore();
 
@@ -104,24 +110,25 @@ test('get CollectData mock error', async () => {
 test('test urlformat', async () => {
     const dataServer: Server = Constants.serverTestData[0];
 
-    let collectDataFetch = await new CollectDataFetch(dataServer,
+    let collectDataFetch = new CollectDataFetch(dataServer,
         'selectedMeasure',
         'startDate',
         'endDate',
+        true,
         selectedPatient);
     expect(collectDataFetch.getUrl())
-        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$collect-data?periodStart=startDate&periodEnd=endDate&subject=selectedPatient');
+        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$collect-data?periodStart=startDate&periodEnd=endDate&subject=Patient/selectedPatient&reportType=subject-list');
 });
 
 test('test urlformat without patient', async () => {
     const dataServer: Server = Constants.serverTestData[0];
-    
-    let collectDataFetch = await new CollectDataFetch(dataServer,
+
+    let collectDataFetch = new CollectDataFetch(dataServer,
         'selectedMeasure',
         'startDate',
         'endDate',
-        {display: '', id: ''});
+        false,
+        { display: '', id: '' });
     expect(collectDataFetch.getUrl())
-        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$collect-data?periodStart=startDate&periodEnd=endDate');
+        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$collect-data?periodStart=startDate&periodEnd=endDate&reportType=subject-list');
 });
- 

--- a/src/tests/data/EvaluateMeasureFetch.test.tsx
+++ b/src/tests/data/EvaluateMeasureFetch.test.tsx
@@ -8,6 +8,8 @@ import jsonTestResultsData from '../resources/fetchmock-results.json';
 
 const selectedPatient = { display: 'John Doe', id: 'selectedPatient' };
 
+const useSubject = true;
+
 beforeEach(() => {
     jest.spyOn(ServerUtils, 'getServerList').mockImplementation(async () => {
         return Constants.serverTestData;
@@ -18,36 +20,41 @@ test('required properties check', async () => {
     const dataServer: Server = Constants.serverTestData[0];
 
     try {
-        new EvaluateMeasureFetch(undefined, selectedPatient,
-            'selectedMeasure', 'startDate', 'endDate');
+        new EvaluateMeasureFetch(undefined,
+            'selectedMeasure', 'startDate', 'endDate',
+            useSubject, selectedPatient);
     } catch (error: any) {
         expect(error.message).toEqual(StringUtils.format(Constants.missingProperty, 'selectedServer'))
     }
 
     try {
-        new EvaluateMeasureFetch(dataServer, selectedPatient,
-            '', 'startDate', 'endDate');
+        new EvaluateMeasureFetch(dataServer,
+            '', 'startDate', 'endDate',
+            useSubject, selectedPatient);
     } catch (error: any) {
         expect(error.message).toEqual(StringUtils.format(Constants.missingProperty, 'selectedMeasure'))
     }
 
     try {
-        new EvaluateMeasureFetch(dataServer, selectedPatient,
-            'selectedMeasure', '', 'endDate');
+        new EvaluateMeasureFetch(dataServer,
+            'selectedMeasure', '', 'endDate',
+            useSubject, selectedPatient);
     } catch (error: any) {
         expect(error.message).toEqual(StringUtils.format(Constants.missingProperty, 'startDate'))
     }
 
     try {
-        new EvaluateMeasureFetch(dataServer, selectedPatient,
-            'selectedMeasure', 'startDate', '');
+        new EvaluateMeasureFetch(dataServer,
+            'selectedMeasure', 'startDate', '',
+            useSubject, selectedPatient);
     } catch (error: any) {
         expect(error.message).toEqual(StringUtils.format(Constants.missingProperty, 'endDate'))
     }
 
     try {
-        new EvaluateMeasureFetch(dataServer, { display: '', id: '' },
-        'selectedMeasure', 'startDate', 'endDate')
+        new EvaluateMeasureFetch(dataServer,
+            'selectedMeasure', 'startDate', 'endDate',
+            useSubject, { display: '', id: '' })
     } catch (error: any) {
         expect(error.message).toEqual(StringUtils.format(Constants.missingProperty, 'Patient or Group'))
     }
@@ -57,11 +64,12 @@ test('required properties check', async () => {
 test('get evaluate measures mock', async () => {
     const dataServer: Server = Constants.serverTestData[0];
 
-    const evaluateMeasuresFetch = new EvaluateMeasureFetch(dataServer, selectedPatient,
-        'selectedMeasure', 'startDate', 'endDate');
+    const evaluateMeasuresFetch = new EvaluateMeasureFetch(dataServer,
+        'selectedMeasure', 'startDate', 'endDate',
+        useSubject, selectedPatient);
 
     expect(evaluateMeasuresFetch.getUrl())
-        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$evaluate-measure?periodStart=startDate&periodEnd=endDate&subject=Patient/selectedPatient');
+        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$evaluate-measure?periodStart=startDate&periodEnd=endDate&subject=Patient/selectedPatient&reportType=subject-list');
 
     const mockJsonResultsData = jsonTestResultsData;
     fetchMock.once(evaluateMeasuresFetch.getUrl(),
@@ -77,11 +85,12 @@ test('get evaluate measures mock', async () => {
 test('test urlformat', async () => {
     const dataServer: Server = Constants.serverTestData[0];
 
-    const evaluateMeasuresFetch = new EvaluateMeasureFetch(dataServer, selectedPatient,
-        'selectedMeasure', 'startDate', 'endDate');
+    const evaluateMeasuresFetch = new EvaluateMeasureFetch(dataServer,
+        'selectedMeasure', 'startDate', 'endDate',
+        useSubject, selectedPatient);
 
     expect(evaluateMeasuresFetch.getUrl())
-        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$evaluate-measure?periodStart=startDate&periodEnd=endDate&subject=Patient/selectedPatient');
+        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$evaluate-measure?periodStart=startDate&periodEnd=endDate&subject=Patient/selectedPatient&reportType=subject-list');
 
 });
 

--- a/src/tests/data/EvaluateMeasureFetch.test.tsx
+++ b/src/tests/data/EvaluateMeasureFetch.test.tsx
@@ -45,6 +45,13 @@ test('required properties check', async () => {
         expect(error.message).toEqual(StringUtils.format(Constants.missingProperty, 'endDate'))
     }
 
+    try {
+        new EvaluateMeasureFetch(dataServer, { display: '', id: '' },
+        'selectedMeasure', 'startDate', 'endDate')
+    } catch (error: any) {
+        expect(error.message).toEqual(StringUtils.format(Constants.missingProperty, 'Patient or Group'))
+    }
+
 });
 
 test('get evaluate measures mock', async () => {
@@ -54,7 +61,7 @@ test('get evaluate measures mock', async () => {
         'selectedMeasure', 'startDate', 'endDate');
 
     expect(evaluateMeasuresFetch.getUrl())
-        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$evaluate-measure?subject=selectedPatient&periodStart=startDate&periodEnd=endDate');
+        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$evaluate-measure?periodStart=startDate&periodEnd=endDate&subject=Patient/selectedPatient');
 
     const mockJsonResultsData = jsonTestResultsData;
     fetchMock.once(evaluateMeasuresFetch.getUrl(),
@@ -74,18 +81,7 @@ test('test urlformat', async () => {
         'selectedMeasure', 'startDate', 'endDate');
 
     expect(evaluateMeasuresFetch.getUrl())
-        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$evaluate-measure?subject=selectedPatient&periodStart=startDate&periodEnd=endDate');
-
-});
-
-test('test urlformat, no patient', async () => {
-    const dataServer: Server = Constants.serverTestData[0];
-
-    const evaluateMeasuresFetch = new EvaluateMeasureFetch(dataServer, { display: '', id: '' },
-        'selectedMeasure', 'startDate', 'endDate');
-
-    expect(evaluateMeasuresFetch.getUrl())
-        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$evaluate-measure?periodStart=startDate&periodEnd=endDate&reportType=subject-list');
+        .toEqual('http://localhost:8080/1/Measure/selectedMeasure/$evaluate-measure?periodStart=startDate&periodEnd=endDate&subject=Patient/selectedPatient');
 
 });
 

--- a/src/tests/resources/fetchmock-test-compare-group.json
+++ b/src/tests/resources/fetchmock-test-compare-group.json
@@ -1,0 +1,113 @@
+{
+  "resourceType": "Bundle",
+  "id": "e31540bc-9410-4a3f-a71c-cd1d7af0fa67",
+  "meta": {
+    "lastUpdated": "2024-09-25T23:27:14.208+00:00"
+  },
+  "type": "searchset",
+  "link": [ {
+    "relation": "self",
+    "url": "http://fhir.ecqm.icfcloud.com/fhir/Group"
+  }, {
+    "relation": "next",
+    "url": "http://fhir.ecqm.icfcloud.com/fhir?_getpages=e31540bc-9410-4a3f-a71c-cd1d7af0fa67&_getpagesoffset=20&_count=20&_pretty=true&_bundletype=searchset"
+  } ],
+  "entry": [ {
+    "fullUrl": "http://fhir.ecqm.icfcloud.com/fhir/Group/17595",
+    "resource": {
+      "resourceType": "Group",
+      "id": "17595",
+      "meta": {
+        "versionId": "1",
+        "lastUpdated": "2024-09-23T20:47:53.103+00:00",
+        "source": "#tekfKz22uqJw8Lbp"
+      },
+      "extension": [ {
+        "url": "http://hl7.org/fhir/StructureDefinition/artifact-testArtifact",
+        "valueCanonical": "http://ecqi.healthit.gov/ecqms/Measure/AlaraCTClinicalFHIR"
+      } ],
+      "active": true,
+      "type": "person",
+      "actual": true,
+      "member": [ {
+        "entity": {
+          "reference": "Patient/9697e375-83a3-4346-bca5-58270068f7d6",
+          "display": "DENOMPass AbdopelrtGood"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/18ec3a01-602c-43a2-adc7-01f861e4ec72",
+          "display": "IPPPass Age18"
+        }
+      },{
+        "entity": {
+          "reference": "Patient/80c4155e-5671-454a-a4ec-5d774fcef8d2",
+          "display": "11yoDepressionScreening IPFail"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/9df7a0b0-f434-4cf0-ba15-6c2094595bf3",
+          "display": "IPPFail ScanOutsideMP"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/84f4944f-543c-4f54-abbd-4ceb0b6d12ec",
+          "display": "IPPFail Under18"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/6d778d8d-a442-4db4-9836-51f6ef27126f",
+          "display": "DENOMFail InvalidUnits"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/fc05f78d-04e9-48ad-bf9c-981038e36814",
+          "display": "NUMERPass HighDose"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/389257a0-b69d-4cac-9e6a-e1674b2a6cc0",
+          "display": "DENOMFail NoUnits"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/e8029124-d760-40eb-b25a-703e447a3e4d",
+          "display": "DENEXPass FullBody"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/7da634ce-7f31-438c-9ae0-3426405a1a0e",
+          "display": "DENOMFail MissingResults"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/568cfa69-fea0-4d54-9e2b-4f82720f36b2",
+          "display": "NUMERPass TwoScans"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/e7a84f8f-69e9-48bb-91d7-72048f405f09",
+          "display": "DENOMPass AbdopelldGood"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/bb32779d-4c41-4113-85af-e534298c4579",
+          "display": "DENOMPass AllScans"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/ba1b91b1-f1ec-4b8f-859c-62a6d140b870",
+          "display": "NUMERPass HighNoise"
+        }
+      }, {
+        "entity": {
+          "reference": "Patient/728a543b-9149-4b2a-9e65-3fb41ce3f35b",
+          "display": "CMOdurDiffEDTestOccur DENEXFail"
+        }
+      } ]
+    },
+    "search": {
+      "mode": "match"
+    }
+  } ]
+}

--- a/src/utils/MeasureComparisonManager.ts
+++ b/src/utils/MeasureComparisonManager.ts
@@ -91,6 +91,8 @@ export class MeasureComparisonManager {
                 sortedArray1[i].code.coding[0].code !== sortedArray2[i].code.coding[0].code ||
                 sortedArray1[i].count !== sortedArray2[i].count
             ) {
+                sortedArray1[i].discrepancy = true;
+                sortedArray2[i].discrepancy = true;
                 return true;
             }
         }

--- a/src/utils/MeasureComparisonManager.ts
+++ b/src/utils/MeasureComparisonManager.ts
@@ -45,7 +45,7 @@ export class MeasureComparisonManager {
         this.selectedMeasureEvaluation = selectedMeasureEvaluation;
         this.startDate = startDate;
         this.endDate = endDate;
-        
+
     }
 
 
@@ -56,19 +56,19 @@ export class MeasureComparisonManager {
      */
     public async fetchGroups() {
         try {
-            
+
             const measureReportFetch = new MeasureReportFetch(this.selectedMeasureEvaluation,
                 this.selectedPatient, this.selectedMeasure.name, this.startDate, this.endDate);
             this.measureReportURL = measureReportFetch.getUrl();
-            
+
             //MeasureReport fetch filters by date manually (period.start/period.end) comes back as entry array
             this.fetchedMeasureReportGroups = ScoringUtils.extractBundleMeasureReportGroupData(await measureReportFetch.fetchData(this.accessToken));
 
 
             const evaluateMeasureFetch = new EvaluateMeasureFetch(this.selectedMeasureEvaluation,
-                this.selectedPatient, this.selectedMeasure.name, this.startDate, this.endDate);
+                this.selectedMeasure.name, this.startDate, this.endDate, true, this.selectedPatient);
             this.evaluatedMeasureURL = evaluateMeasureFetch.getUrl();
-             
+
             //evaluate measure comes back as a single MeasureReport
             this.fetchedEvaluatedMeasureGroups = ScoringUtils.extractMeasureReportGroupData((await evaluateMeasureFetch.fetchData(this.accessToken)).jsonBody);
 
@@ -77,7 +77,7 @@ export class MeasureComparisonManager {
             console.log(error);
         }
     }
- 
+
 
     private compareMeasureGroups(): boolean {
         if (this.fetchedEvaluatedMeasureGroups.length !== this.fetchedMeasureReportGroups.length) {

--- a/src/utils/PatientGroupUtils.ts
+++ b/src/utils/PatientGroupUtils.ts
@@ -2,7 +2,7 @@ import { PatientGroup } from "../models/PatientGroup";
 import { Patient } from "../models/Patient";
 
 export class PatientGroupUtils {
-    public static patientExistsInGroup(patientEntry: Patient, selectedMeasureGroup: PatientGroup): boolean {
+    public static patientExistsInGroup(patientEntry: Patient | undefined, selectedMeasureGroup: PatientGroup | undefined): boolean {
         if (!patientEntry?.id || !selectedMeasureGroup?.member) {
             return false;
         }


### PR DESCRIPTION
- Adding in ability to define subject 
- Group array in measure report returned by measure valuation now looped through
- Disabling dropdowns based on loading boolean
- Added checklist to Test Comparator window to visually show the user what's needed for the test
- Updated test coverage 
- selecting new measure resets items like test comparator and selected patient

Test comparison summary tightened up and includes feedback from connectathon:
 ![image](https://github.com/user-attachments/assets/450a77a5-157b-4c21-aebb-1e7d6fcee86b)

When no test summary is present, I have a little checklist in the card area so a user can visually see what's needed to generate the summary (it's just ascii, no images):
 
![image](https://github.com/user-attachments/assets/ac70551b-8c86-4838-8ce1-639b6d407627)

 
 
I modified Populations so that scoring used flex wrap with a dynamic width based on the number of groups. If it's one group, it gets 100% width, if it's 2, it gets split into two columns (50%), and if it's 3 or more it gets split up into 3 columns of 33%. Here's GlobalMalnutritionComposite which has 6 groups:
 
![image](https://github.com/user-attachments/assets/50890962-7fb2-4022-b421-ce14bedeacd8)

 
here's OncologyPainIntensityQuantified which has 2:
 
![image](https://github.com/user-attachments/assets/0dbf1a3c-2237-4111-a735-270525642f25)

and for the most common, a single entry in the group array:
 
![image](https://github.com/user-attachments/assets/ea7cf11f-0cc3-4b47-9a18-0a4daccc6cc6)

I also modified the 'selected' string that shows up when our data repo card is hidden to focus on subject/server:
 
![image](https://github.com/user-attachments/assets/b2ff9704-a72d-4b91-8335-c6d894a049fb)
![image](https://github.com/user-attachments/assets/b076d391-e7b8-4bc5-b722-44a9277dc880)

 
If nothing is selected:

![image](https://github.com/user-attachments/assets/d7281ad7-1f74-46d2-9152-3dd11e543188)
