### PR TITLE
Color adjustments 

### DIFF
--- a/src/components/SectionalResults.tsx
+++ b/src/components/SectionalResults.tsx
@@ -74,8 +74,7 @@ const SectionalResults: React.FC<Props> = ({ results }) => {
         <div
           className='card row'
           style={{
-            background: isError ? 'var(--error)' : 'var(--success)',
-            border: 'solid 1px lightgrey',
+            background: isError ? 'var(--error)' : 'var(--notify_bg)',
             margin: '0px',
             padding: '6px',
             width: isError ? 'auto' : '96.9%',

--- a/src/css/global-overrides.css
+++ b/src/css/global-overrides.css
@@ -8,6 +8,8 @@
     --focus-shadow: #282828;
     --error: #aa0000;
     --success: #026500;
+    --notify_bg: #e8e8e8;
+
 }
 
 .showAllHideAll {
@@ -75,6 +77,15 @@ button[type="reset"]:active {
     border: 1px solid var(--focus-shadow) !important;
     color: var(--text-color) !important;
 }
+
+button[type="submit"]:disabled,
+button[type="button"]:disabled,
+button[type="reset"]:disabled {
+    background-color: var(--focus-shadow) !important;
+    border: 1px solid var(--focus-shadow) !important;
+    color: var(--text-color) !important;
+}
+ 
  
 a,
 .btn-link {


### PR DESCRIPTION
Testing the version deployed I noticed the background color of the notification style sectional results panel was set to green. I also saw the disabled button state was missed. The panel background is set to a very light grey, and the disabled state for buttons has been set to grey background white text.